### PR TITLE
Allow checking block membership by in keyword

### DIFF
--- a/yastn/tensor/__init__.py
+++ b/yastn/tensor/__init__.py
@@ -113,7 +113,7 @@ class Tensor:
     from ._single import copy, clone, detach, to, requires_grad_, remove_zero_blocks, add_leg, remove_leg, drop_leg_history
     from ._output import show_properties, __str__, print_blocks_shape, is_complex
     from ._output import get_blocks_charge, get_blocks_shape, get_leg_charges_and_dims, get_leg_structure, get_legs
-    from ._output import zero_of_dtype, item, __getitem__
+    from ._output import zero_of_dtype, item, __getitem__, __contains__
     from ._output import get_leg_fusion, get_shape, get_signature, get_dtype
     from ._output import get_tensor_charge, get_rank
     from ._output import to_number, to_dense, to_numpy, to_raw_tensor, to_nonsymmetric

--- a/yastn/tensor/_output.py
+++ b/yastn/tensor/_output.py
@@ -278,6 +278,11 @@ def __getitem__(a, key) -> numpy.ndarray | torch.tensor:
     # TODO this should be reshape called from backend ?
     return x if a.isdiag else x.reshape(a.struct.D[ind])
 
+def __contains__(a, key) -> bool:
+    key = tuple(_flatten(key)) if (hasattr(key,'__iter__') or hasattr(key,'__next__')) else (key,)
+    if a.isdiag: 
+        return key in a.struct.t or (key+key) in a.struct.t
+    return key in a.struct.t
 
 ##################################################
 #    output tensors info - advanced structure    #


### PR DESCRIPTION
Implements ``__contains__`` on Tensor, allowing for membership test of a block with charges ``c``, i.e.,

```
if c in T:
   ...
```

If T is diagonal, both ``c`` and ``(c,c)`` can be checked for, returning ``True`` if block ``(c,c)`` exists within ``T.struct.t``  

```
if (c,c) in T.struct.t:
    (c in T and (c,c) in T) == True
```

For hard-fused tensors, fused charges are to be used, whole for meta-fused tensors, original charges have to be used.
