### PR TITLE
fix "SyntaxWarning: invalid escape sequence" appearing during the tests

### DIFF
--- a/tests/mps/test_dmrg.py
+++ b/tests/mps/test_dmrg.py
@@ -123,14 +123,14 @@ def dmrg_XX_model_dense(config=None, tol=1e-6):
     parameters = {"t": 1.0, "mu": 0.2,
                   "rN": range(N),
                   "rNN": [(i, i+1) for i in range(N - 1)]}
-    H_str = "\sum_{i,j \in rNN} t ( sp_{i} sm_{j} + sp_{j} sm_{i} )"
-    H_str += " + \sum_{j \in rN} mu sp_{j} sm_{j}"
+    H_str = r"\sum_{i,j \in rNN} t ( sp_{i} sm_{j} + sp_{j} sm_{i} )"
+    H_str += r" + \sum_{j \in rN} mu sp_{j} sm_{j}"
     H = generate.mpo_from_latex(H_str, parameters)
     #
     # and MPO to measure occupation:
     #
-    O_occ = generate.mpo_from_latex("\sum_{j \in rN} sp_{j} sm_{j}",
-                                  parameters)
+    O_occ = generate.mpo_from_latex(r"\sum_{j \in rN} sp_{j} sm_{j}",
+                                    parameters)
     #
     # Known energies and occupations of low-energy eigenstates.
     #
@@ -194,13 +194,13 @@ def dmrg_XX_model_Z2(config=None, tol=1e-6):
             [4, 2, 4]),
         1: ([-3.427339492125, -2.661972627395, -2.261972627395],
             [3, 3, 5])}
-    H_str = "\sum_{i,j \in rNN} t (cp_{i} c_{j} + cp_{j} c_{i})"
-    H_str += " + \sum_{j\in rN} mu cp_{j} c_{j}"
+    H_str = r"\sum_{i,j \in rNN} t (cp_{i} c_{j} + cp_{j} c_{i})"
+    H_str += r" + \sum_{j\in rN} mu cp_{j} c_{j}"
     parameters = {"t": 1.0, "mu": 0.2,
                   "rN": range(N),
                   "rNN": [(i, i+1) for i in range(N - 1)]}
     H = generate.mpo_from_latex(H_str, parameters)
-    O_occ = generate.mpo_from_latex("\sum_{j\in rN} cp_{j} c_{j}", parameters)
+    O_occ = generate.mpo_from_latex(r"\sum_{j\in rN} cp_{j} c_{j}", parameters)
 
     for parity, (E_target, occ_target) in Eng_occ_target.items():
         psi = generate.random_mps(D_total=Dmax, n=parity)
@@ -220,13 +220,13 @@ def dmrg_XX_model_U1(config=None, tol=1e-6):
     generate.random_seed(seed=0)
 
     N = 7
-    H_str = "\sum_{i,j \in rNN} t (cp_{i} c_{j} + cp_{j} c_{i})"
-    H_str += " + \sum_{j\in rN} mu cp_{j} c_{j}"
+    H_str = r"\sum_{i,j \in rNN} t (cp_{i} c_{j} + cp_{j} c_{i})"
+    H_str += r" + \sum_{j\in rN} mu cp_{j} c_{j}"
     parameters = {"t": 1.0, "mu": 0.2,
                   "rN": range(N),
                   "rNN": [(i, i+1) for i in range(N - 1)]}
     H = generate.mpo_from_latex(H_str, parameters)
-    O_occ = generate.mpo_from_latex("\sum_{j\in rN} cp_{j} c_{j}", parameters)
+    O_occ = generate.mpo_from_latex(r"\sum_{j\in rN} cp_{j} c_{j}", parameters)
 
     Eng_sectors = {
         2: [-2.861972627395, -2.213125929752], #  -1.779580427103],
@@ -256,13 +256,13 @@ def test_dmrg_XX_model_U1_sum_of_Mpos(config=cfg, tol=1e-6):
     generate.random_seed(seed=0)
 
     N = 7
-    H_str_nn = "\sum_{i,j \in rNN} (cp_{i} c_{j} + cp_{j} c_{i})"
-    H_str_n  = "\sum_{j \in rN} cp_{j} c_{j}"
+    H_str_nn = r"\sum_{i,j \in rNN} (cp_{i} c_{j} + cp_{j} c_{i})"
+    H_str_n  = r"\sum_{j \in rN} cp_{j} c_{j}"
     parameters = {"rN": list(range(N)),
                   "rNN": [(i, i+1) for i in range(N - 1)]}
     H_nn = generate.mpo_from_latex(H_str_nn, parameters)
     H_n = generate.mpo_from_latex(H_str_n, parameters)
-    O_occ = generate.mpo_from_latex("\sum_{j \in rN} cp_{j} c_{j}", parameters)
+    O_occ = generate.mpo_from_latex(r"\sum_{j \in rN} cp_{j} c_{j}", parameters)
 
     Eng_sectors = {
         2: [-2.861972627395, -2.213125929752], #  -1.779580427103],

--- a/tests/mps/test_generator_class.py
+++ b/tests/mps/test_generator_class.py
@@ -38,8 +38,8 @@ def mpo_nn_hopping_latex(N, t, mu, sym="U1", config=None):
     # pytest uses config to inject various backends and devices for testing
     ops = yastn.operators.SpinlessFermions(sym=sym, **opts_config)
 
-    Hstr = "\sum_{j,k \in NN} t (cp_{j} c_{k}+cp_{k} c_{j})"
-    Hstr += " + \sum_{i \in sites} mu cp_{i} c_{i}"
+    Hstr = r"\sum_{j,k \in NN} t (cp_{j} c_{k}+cp_{k} c_{j})"
+    Hstr += r" + \sum_{i \in sites} mu cp_{i} c_{i}"
     parameters = {"t": t,
                   "mu": mu,
                   "sites": list(range(N)),
@@ -63,7 +63,7 @@ def test_nn_hopping_latex_map(config=cfg, tol=1e-12):
     opts_config = {} if config is None else \
                   {'backend': config.backend,
                    'default_device': config.default_device}
-    H_str = "\sum_{j,k \in NN} t_{j,k} (cp_{j} c_{k}+cp_{k} c_{j}) + \sum_{i \in sites} mu cp_{i} c_{i}"
+    H_str = r"\sum_{j,k \in NN} t_{j,k} (cp_{j} c_{k}+cp_{k} c_{j}) + \sum_{i \in sites} mu cp_{i} c_{i}"
     for sym in ['Z2', 'U1']:
         ops = yastn.operators.SpinlessFermions(sym=sym, **opts_config)
         for t in [0, 0.2, -0.3]:
@@ -106,8 +106,8 @@ def mpo_hopping_latex(J=np.array([[0.5, 1], [0, 0.2]]), sym="U1", config=None):
 
     N = len(J)
 
-    Hstr = "\sum_{j,k \in NN} J_{j,k} (cp_{j} c_{k}+cp_{k} c_{j})"
-    Hstr += " + \sum_{i \in sites} J_{i,i} cp_{i} c_{i}"
+    Hstr = r"\sum_{j,k \in NN} J_{j,k} (cp_{j} c_{k}+cp_{k} c_{j})"
+    Hstr += r" + \sum_{i \in sites} J_{i,i} cp_{i} c_{i}"
     parameters = {"J": J,
                   "sites": list(range(N)),
                   "NN": list((i, j) for i in range(N-1)
@@ -138,8 +138,8 @@ def test_mpo_hopping_latex(config=cfg, tol=1e-12):
 
     # define parameters for automatic generator and Hamiltonian in a latex-like form
     eparam ={"t": t, "mu": mu, 'sites': list(range(N))}
-    Hstr = "\sum_{j\in sites} \sum_{k\in sites} t_{j,k} (cp_{j} c_{k} + cp_{k} c_{j})"
-    Hstr += " + \sum_{j\in sites} mu_{j} cp_{j} c_{j}"
+    Hstr = r"\sum_{j\in sites} \sum_{k\in sites} t_{j,k} (cp_{j} c_{k} + cp_{k} c_{j})"
+    Hstr += r" + \sum_{j\in sites} mu_{j} cp_{j} c_{j}"
 
     H1 = generate.mpo_from_latex(Hstr, eparam)
     H2 = build_mpo_hopping_Hterm(J, sym=sym, config=config)
@@ -154,10 +154,10 @@ def test_latex2term_unit_tests():
     examples_A = ("   s_j   + d_j    +   1 + 2  + 3 ", \
                 "   s_j   - d_j    +   1 - 2  + 3 ",\
                 "s_j-d_j+1-2+3",\
-                "\sum_{j\in range} (a_j + b_j)",\
-                "\sum_{j \in   range}  (a_j + b_j)",\
-                "\sum_{j\inrange}  (a_j + b_j)",\
-                "\sum_{j\in range}\sum_{k\in range_L}(a_j+b_k)   ",\
+                r"\sum_{j\in range} (a_j + b_j)",\
+                r"\sum_{j \in   range}  (a_j + b_j)",\
+                r"\sum_{j\inrange}  (a_j + b_j)",\
+                r"\sum_{j\in range}\sum_{k\in range_L}(a_j+b_k)   ",\
                 )
     test_examples_A1 = (["s_j","+","d_j","+","1","+","2","+","3"],\
                     ["s_j","+","minus",'*',"d_j","+","1","+","minus",'*',"2","+","3"],\
@@ -205,12 +205,12 @@ def test_latex2term_unit_tests():
         assert interpret(splitt(string2list(x),0), {}) == test_x
 
     # Test interpreter with sum substitution
-    examples_C =["\sum_{j\in range} (a_{j}  b_{j})",
-                 "\sum_{j\in range}\sum_{k\in range_L} a_{j} b_{j}",
-                 "\sum_{j \in   range}  (a_{j} + b_{j})",
-                 "\sum_{j\inrange}  (a_{j} + b_{j})",
-                 "\sum_{j\in range}\sum_{k\in range_L}(a_{j}+b_{k})   ",
-                 "\sum_{i,j\in NN} A_{i,j} ap_{i} a_{j}"]
+    examples_C =[r"\sum_{j\in range} (a_{j}  b_{j})",
+                 r"\sum_{j\in range}\sum_{k\in range_L} a_{j} b_{j}",
+                 r"\sum_{j \in   range}  (a_{j} + b_{j})",
+                 r"\sum_{j\inrange}  (a_{j} + b_{j})",
+                 r"\sum_{j\in range}\sum_{k\in range_L}(a_{j}+b_{k})   ",
+                 r"\sum_{i,j\in NN} A_{i,j} ap_{i} a_{j}"]
     test_examples_C1 = [[single_term(op=(('a', 'i1'), ('b', 'i1'))), single_term(op=(('a', 'i2'), ('b', 'i2'))), single_term(op=(('a', 'i3'), ('b', 'i3')))],\
                         [single_term(op=(('a', 'i1'), ('b', 'i1'))), single_term(op=(('a', 'i1'), ('b', 'i1'))), single_term(op=(('a', 'i1'), ('b', 'i1'))), single_term(op=(('a', 'i2'), ('b', 'i2'))), single_term(op=(('a', 'i2'), ('b', 'i2'))), single_term(op=(('a', 'i2'), ('b', 'i2'))), single_term(op=(('a', 'i3'), ('b', 'i3'))), single_term(op=(('a', 'i3'), ('b', 'i3'))), single_term(op=(('a', 'i3'), ('b', 'i3')))],
                         [single_term(op=(('a', 'i1'),)), single_term(op=(('b', 'i1'),)), single_term(op=(('a', 'i2'),)), single_term(op=(('b', 'i2'),)), single_term(op=(('a', 'i3'),)), single_term(op=(('b', 'i3'),))],

--- a/yastn/tn/mps/_latex2term.py
+++ b/yastn/tn/mps/_latex2term.py
@@ -302,7 +302,7 @@ def splitt(b, eq_it):
     return operation, list(map(lambda x: splitt(x, (eq_it + 1)%len(basic_operation)), tunnel))
 
 def string2list(c0):
-    """
+    r"""
     Helper function.
 
     Take the latex-like intruction in a form of a string and put in an input format
@@ -330,12 +330,12 @@ def string2list(c0):
     else:
         # replace muiltiple spaces with a single space
         c0 = c0.replace("-", " + minus * ")
-        c0 = c0.replace("\sum_", " sum ")
+        c0 = c0.replace(r"\sum_", " sum ")
         for ix in ["+","*","(",")"]:
             c0 = c0.replace(ix, " "+ix+" ")
         c0 = " ".join(c0.split())
-        c0 = c0.replace(" \in", "\in").replace("\in ", "\in")
-        c0 = c0.replace("\in", ".in.")
+        c0 = c0.replace(r" \in", r"\in").replace(r"\in ", r"\in")
+        c0 = c0.replace(r"\in", ".in.")
         return c0.split(" ")
 
 


### PR DESCRIPTION
Nice library! While writing a report for your [scipost physics codebase submission](https://scipost.org/submissions/scipost_202406_00058v1/), I tried running the tests and saw a bunch of `syntax warnings: invalid escape sequence` ocuring from the latex strings used for MPO generation. I've marked those strings as python raw strings by prefixing them with r, hence suppressing those warnings.
(If I'm not mistaken, those warnings appear only with sufficiently recent Python versions - I tested with Python 3.12.)

Feel free to dismiss this PR if you don't think that's necessary and want to dismiss the warnings.