### PR TITLE
Feat svds refactor

### DIFF
--- a/tests/tensor/test_svd.py
+++ b/tests/tensor/test_svd.py
@@ -432,7 +432,7 @@ def test_svd_arnoldi(config_kwargs):
         a = yastn.rand(config=config_U1, s=(-1, -1, 1, 1),
                        t=[(0, 1), (0, 1), (0, 1), (0, 1)],
                        D=[(2, 3), (4, 5), (4, 3), (2, 1)], dtype=dtype)
-        U0, S0, V0 = yastn.svd(a, policy='arnoldi', D_block=1, axes=((0, 1), (2, 3)), fix_signs=True)
+        U0, S0, V0 = yastn.svd(a, policy='block_arnoldi', D_block=1, axes=((0, 1), (2, 3)), fix_signs=True)
         U1, S1, V1 = yastn.svd_with_truncation(a, D_block=1, axes=((0, 1), (2, 3)), fix_signs=True)
         assert (S0 - S1).norm() < tol
         assert (U0 - U1).norm() < tol
@@ -440,7 +440,6 @@ def test_svd_arnoldi(config_kwargs):
 
     # add backwards when available in svd(policy='arnoldi')
     # import torch
-
 
 
 def test_svd_exceptions(config_kwargs):

--- a/tests/tensor/test_torch_linalg.py
+++ b/tests/tensor/test_torch_linalg.py
@@ -21,7 +21,7 @@ torch_test = pytest.mark.skipif("'torch' not in config.getoption('--backend')",
 @torch_test
 def test_SVDSYMARNOLDI_random():
     import torch
-    from yastn.backend.linalg.torch_svd_arnoldi import SVDSYMARNOLDI
+    from yastn.backend.linalg.torch_svds_scipy import SVDSYMARNOLDI
 
     m = 50
     k = 10
@@ -40,14 +40,14 @@ def test_SVDSYMARNOLDI_random():
 @torch_test
 def test_SVDARNOLDI_random():
     import torch
-    from yastn.backend.linalg.torch_svd_arnoldi import SVDARNOLDI
+    from yastn.backend.linalg.torch_svds_scipy import SVDS_SCIPY
 
     m = 50
     k = 10
     M = torch.rand((m, m), dtype=torch.float64)
     U0, S0, V0 = torch.svd(M)
 
-    U , S, V = SVDARNOLDI.apply(M, k)
+    U , S, V = SVDS_SCIPY.apply(M, k)
     # |M|=\sqrt{Tr(MM^t)}=\sqrt{Tr(D^2)} =>
     # |M-US_kV^t|=\sqrt{Tr(D^2)-Tr(S^2)}=\sqrt{\sum_i>k D^2_i}
     assert abs(torch.norm(M - U @ torch.diag(S) @ V) - torch.sqrt(torch.sum(S0[k:] ** 2))) < S0[0] * m**2 * 1e-14
@@ -56,7 +56,7 @@ def test_SVDARNOLDI_random():
 @torch_test
 def test_SVDARNOLDI_rank_deficient():
     import torch
-    from yastn.backend.linalg.torch_svd_arnoldi import SVDARNOLDI
+    from yastn.backend.linalg.torch_svds_scipy import SVDS_SCIPY
 
     m = 50
     k = 15
@@ -66,7 +66,7 @@ def test_SVDARNOLDI_rank_deficient():
         S0[-r:] = 0
         M = U @ torch.diag(S0) @ V.t()
 
-        U, S, V = SVDARNOLDI.apply(M, k)
+        U, S, V = SVDS_SCIPY.apply(M, k)
         assert abs(torch.norm(M - U @ torch.diag(S) @ V) - torch.sqrt(torch.sum(S0[k:] ** 2))) < S0[0] * m**2 * 1e-14
 
 

--- a/yastn/backend/_backend_torch_backwards.py
+++ b/yastn/backend/_backend_torch_backwards.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 
 from .linalg.torch_svd_gesdd import SVDGESDD
-from .linalg.torch_svd_arnoldi import SVDARNOLDI
+from .linalg.torch_svds_scipy import SVDS_SCIPY
 # from .linalg.torch_eig_arnoldi import SYMARNOLDI, SYMARNOLDI_2C
 
 
@@ -66,16 +66,16 @@ class kernel_svd(torch.autograd.Function):
         return data_b, None, None, None, None, None
 
 
-class kernel_svd_arnoldi(torch.autograd.Function):
+class kernel_svds_scipy(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, data, meta, sizes, thresh, solver):
+    def forward(ctx, data, meta, sizes, thresh, solver, **kwargs):
         real_dtype = data.real.dtype if data.is_complex() else data.dtype
         Udata = torch.empty((sizes[0],), dtype=data.dtype, device=data.device)
         Sdata = torch.empty((sizes[1],), dtype=real_dtype, device=data.device)
         Vhdata = torch.empty((sizes[2],), dtype=data.dtype, device=data.device)
         for (sl, D, slU, DU, slS, slV, DV) in meta:
             k = slS[1] - slS[0]
-            U, S, V = SVDARNOLDI.apply(data[slice(*sl)].view(D), k, thresh, solver)
+            U, S, V = SVDS_SCIPY.apply(data[slice(*sl)].view(D), k, thresh, solver, **kwargs)
             Udata[slice(*slU)].reshape(DU)[:] = U
             Sdata[slice(*slS)] = S
             Vhdata[slice(*slV)].reshape(DV)[:] = V

--- a/yastn/tensor/linalg.py
+++ b/yastn/tensor/linalg.py
@@ -22,6 +22,9 @@ from ._tests import YastnError, _test_axes_all
 from ._merging import _merge_to_matrix, _meta_unmerge_matrix, _unmerge
 from ._merging import _Fusion, _leg_struct_trivial
 # from ..krylov._krylov import svds
+import sys
+import logging
+logger= logging.getLogger(__name__)
 
 __all__ = ['qr', 'norm', 'entropy', 'truncation_mask', 'truncation_mask_multiplets',
            'svd', 'svd_with_truncation', 'eigh', 'eigh_with_truncation']
@@ -102,6 +105,7 @@ def svd_with_truncation(a, axes=(0, 1), sU=1, nU=True,
     -------
     `U`, `S`, `V`
     """
+    verbosity = kwargs.get('verbosity', 0)
     U, S, V = svd(a, axes=axes, sU=sU, nU=nU, policy=policy, D_block=D_block,
                   fix_signs=fix_signs, svd_on_cpu=svd_on_cpu, **kwargs)
     Smask = truncation_mask(S, tol=tol, tol_block=tol_block,
@@ -110,6 +114,11 @@ def svd_with_truncation(a, axes=(0, 1), sU=1, nU=True,
                             mask_f=mask_f)
 
     U, S, V = Smask.apply_mask(U, S, V, axes=(-1, 0, 0))
+    if verbosity>2:
+        fname = sys._getframe().f_code.co_name
+        logger.info(f"{fname} truncation_mask tol {tol} tol_block {tol_block} D_total {D_total}")
+        logger.info(f"truncation_mask D_block {D_block}")
+        logger.info(f"{fname} S {S.get_legs(0)}")
 
     U = U.moveaxis(source=-1, destination=Uaxis)
     V = V.moveaxis(source=0, destination=Vaxis)
@@ -118,7 +127,7 @@ def svd_with_truncation(a, axes=(0, 1), sU=1, nU=True,
 
 def svd(a, axes=(0, 1), sU=1, nU=True, compute_uv=True,
         Uaxis=-1, Vaxis=0, policy='fullrank',
-        fix_signs=False, svd_on_cpu=False, **kwargs) -> tuple[yastn.Tensor, yastn.Tensor, yastn.Tensor] | yastn.Tensor:
+        fix_signs=False, svd_on_cpu=False, thresh= 0.1, **kwargs) -> tuple[yastn.Tensor, yastn.Tensor, yastn.Tensor] | yastn.Tensor:
     r"""
     Split tensor into :math:`a = U S V` using exact singular value decomposition (SVD),
     where the columns of `U` and the rows of `V` form orthonormal bases
@@ -147,10 +156,23 @@ def svd(a, axes=(0, 1), sU=1, nU=True, compute_uv=True,
         it is the last leg of `U` and the first of `V`, in which case ``a = U @ S @ V``.
 
     policy: str
-        ``"fullrank"`` or ``"lowrank"`` are allowed. Use standard full (but reduced) SVD for ``"fullrank"``.
-        For ``"lowrank"``, uses randomized/truncated SVD and requires providing ``D_block`` in ``kwargs``.
-        This employs ``scipy.sparse.linalg.svds`` for numpy backend; and ``torch.svd_lowrank`` for torch backend.
+        Driver for computing SVD or partial SVD
+
+            * (default) ``"fullrank"`` compute full SVD then truncate.
+            * ``"lowrank"`` default policy for partial SVD.
+                On NumPy backend uses ``block_arnoldi``. On torch backend uses ``block_arnoldi``.
+            * ``"randomized"`` randomized SVD up to desired size in each block. Requires providing ``D_block`` in ``kwargs``.
+                Requires torch backend and uses ``torch.svd_lowrank``.
+            * ``"block_arnoldi"`` partial SVD using scipy's svds arnoldi method. Requires providing ``D_block`` in ``kwargs``.
+            * ``"block_propack"`` partial SVD using scipy's svds propack method. Requires providing ``D_block`` in ``kwargs``.
+        
         kwargs will be passed to those functions for non-default settings.
+
+    thresh: float
+        In case of ``policy='block_arnoldi'`` or ``policy='block_propack'``,
+        threshold on minimal block size for applying partial SVD solver instead of full SVD.
+        The default is ``thresh=0.1``. If for a matrix of size :math:`N \times N` 
+         ``N*thresh`` < requested number of singular triples a full SVD is applied.
 
     fix_signs: bool
         Whether or not to fix phases in `U` and `V`,
@@ -169,6 +191,14 @@ def svd(a, axes=(0, 1), sU=1, nU=True, compute_uv=True,
     -------
     `U`, `S`, `V` (when ``compute_uv=True``) or `S` (when ``compute_uv=False``)
     """
+    POLICIES = ['fullrank', 'lowrank', 'randomized', 'block_arnoldi', 'block_propack', 'krylov']
+    # 1. validation
+    if policy not in POLICIES:
+       raise YastnError(f"Invalid SVD solver/policy {policy}. Choose one of {POLICIES}.")
+    _test_axes_all(a, axes)
+    
+    # 2. Global solvers
+    verbosity= kwargs.get('verbosity', 0)
     if policy == "krylov":
         from ..krylov._krylov import svds
         if 'D_block' not in kwargs:
@@ -179,28 +209,38 @@ def svd(a, axes=(0, 1), sU=1, nU=True, compute_uv=True,
             U, S, Vh = svds(a, axes=axes, sU=sU, nU=nU, k=D_block, ncv=None, tol=0, which='LM', solver='arpack')
             return U, S, Vh
 
-
-    _test_axes_all(a, axes)
+    # 3. Continue with block-wise SVD
     lout_l, lout_r = _clear_axes(*axes)
     axes = _unpack_axes(a.mfs, lout_l, lout_r)
-
     data, struct, slices, ls_l, ls_r = _merge_to_matrix(a, axes)
 
+    # TODO should this be handled by user ?
     if svd_on_cpu:
         device = a.config.backend.get_device(data)
         data = a.config.backend.move_to(data, device='cpu')
 
+    # 3.1 Set minimal number of singular triples to solve for in each block. 
+    #     Used by block-wise partial SVD and ignored by 'fullrank' policy.
     minD = tuple(min(ds) for ds in struct.D)
-    if policy == 'lowrank' or policy == 'arnoldi':
+    if policy in ['lowrank', 'randomized', 'block_arnoldi', 'block_propack']:
         if 'D_block' not in kwargs:
             raise YastnError(policy + " policy in svd requires passing argument D_block.")
         D_block = kwargs['D_block']
         if not isinstance(D_block, dict):
             minD = tuple(min(D_block, d) for d in minD)
         else:
+            # Presumably {charge: D} data (D_block) for leg to be attached to U with signature sU
+            # TODO: control default for sectors not present in D_block
+            sector_minD= min(D_block.values())
             nsym = a.config.sym.NSYM
             st = [x[nsym:] for x in struct.t] if nU else [x[:nsym] for x in struct.t]
-            minD = tuple(min(D_block.get(t, 0), d) for t, d in zip(st, minD))
+            minD = tuple(min(D_block.get(t, sector_minD), d) for t, d in zip(st, minD))
+    
+    if verbosity>2:
+        fname = sys._getframe().f_code.co_name
+        logger.info(f"{fname} {policy} struct.D {struct.D}")
+        logger.info(f"{fname} D_block {kwargs.get('D_block', 'NA')}")
+        logger.info(f"{fname} minD {minD}")
 
     meta, Ustruct, Uslices, Sstruct, Sslices, Vstruct, Vslices = _meta_svd(a.config, struct, slices, minD, sU, nU)
     sizes = tuple(x.size for x in (Ustruct, Sstruct, Vstruct))
@@ -211,13 +251,19 @@ def svd(a, axes=(0, 1), sU=1, nU=True, compute_uv=True,
         Sdata = a.config.backend.svdvals(data, meta, sizes[1])
     elif compute_uv and policy == 'lowrank':
         Udata, Sdata, Vdata = a.config.backend.svd_lowrank(data, meta, sizes)
-    elif compute_uv and policy == 'arnoldi':
-        thresh = kwargs.get('svds_thresh', 0.2)
-        solver = kwargs.get('svds_solver', 'arpack')
-        Udata, Sdata, Vdata = a.config.backend.svd_arnoldi(data, meta, sizes, thresh, solver)
+    elif policy == 'randomized': # always computes partial U and V
+        Udata, Sdata, Vdata = a.config.backend.svd_randomized(data, meta, sizes, **kwargs)
+    elif compute_uv and policy in ['block_arnoldi', 'block_propack']:
+        thresh = kwargs.get('svds_thresh', 0.1)
+        if policy == 'block_arnoldi':
+            solver = 'arpack'
+        elif policy == 'block_propack':
+            solver = 'propack'
+        Udata, Sdata, Vdata = a.config.backend.svds_scipy(data, meta, sizes, thresh, solver)
     else:
-        raise YastnError('svd() policy should in (`arnoldi`, `lowrank`, `fullrank`). compute_uv == False only works with `fullrank`')
+        raise YastnError("compute_uv == False is supported only for policy='fullrank'")
 
+    # 4. post-processing
     if svd_on_cpu:
         Sdata = a.config.backend.move_to(Sdata, device=device)
         if compute_uv:
@@ -399,6 +445,11 @@ def truncation_mask_multiplets(S, tol=0, D_total=float('inf'),
     if not (S.isdiag and S.yastn_dtype == "float64"):
         raise YastnError("Truncation_mask requires S to be real and diagonal.")
 
+    verbosity = kwargs.get('verbosity', 0)
+    if verbosity>2:
+        fname = sys._getframe().f_code.co_name
+        logger.info(f"{fname} tol {tol} tol_block {tol_block} D_total {D_total}")
+
     # makes a copy for partial truncations; also detaches from autograd computation graph
     Smask = S.copy()
     Smask._data = Smask.data > float('inf') # all False ?
@@ -506,6 +557,12 @@ def truncation_mask(S, tol=0, tol_block=0,
 
     if not (S.isdiag and S.yastn_dtype == "float64"):
         raise YastnError("truncation_mask() requires S to be real and diagonal.")
+    
+    verbosity = kwargs.get('verbosity', 0)
+    if verbosity>2:
+        fname = sys._getframe().f_code.co_name
+        logger.info(f"{fname} tol {tol} tol_block {tol_block} D_total {D_total}")
+        logger.info(f"{fname} D_block {D_block}")
 
     # makes a copy for partial truncations; also detaches from autograd computation graph
     S = S.copy()

--- a/yastn/tn/fpeps/envs/_env_ctm.py
+++ b/yastn/tn/fpeps/envs/_env_ctm.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import NamedTuple, Union, Callable, Sequence
-import logging
 from .... import Tensor, rand, ones, eye, YastnError, Leg, tensordot, qr, truncation_mask, vdot, decompress_from_1d
 from ....operators import sign_canonical_order
 from ... import mps
@@ -27,7 +26,9 @@ from ._env_window import EnvWindow
 from ._env_measure import _measure_nsite
 from ._env_boundary_mps import _clear_operator_input
 
-logger = logging.Logger('ctmrg')
+import sys
+import logging
+logger= logging.getLogger(__name__)
 
 @dataclass()
 class EnvCTM_local():
@@ -196,6 +197,23 @@ class EnvCTM(Peps):
                '2layer': isinstance(env.psi, Peps2Layers), 'geometry': env.geometry, 'sites': env.sites()}
         data= tuple( t for t,m in unrolled['psi'].values())+tuple( t for t,m in unrolled['env'])
         return data, meta
+
+    def save_to_dict(self) -> dict:
+        r"""
+        Serialize EnvCTM into a dictionary.
+        """
+        psi = self.psi
+        if isinstance(psi, Peps2Layers):
+            psi = psi.ket
+
+        d = {'class': 'EnvCTM',
+             'psi': psi.save_to_dict(),
+             'data': {}}
+        for site in self.sites():
+            d_local = {dirn: getattr(self[site], dirn).save_to_dict()
+                       for dirn in ['tl', 'tr', 'bl', 'br', 't', 'l', 'b', 'r']}
+            d['data'][site] = d_local
+        return d
 
 
     def reset_(self, init='rand', leg=None, **kwargs):
@@ -1013,23 +1031,6 @@ class EnvCTM(Peps):
         g = g / g.trace(axes=(0, 1)).to_number()
         return g.unfuse_legs(axes=(0, 1)).fuse_legs(axes=((1, 3), (0, 2)))
 
-    def save_to_dict(self) -> dict:
-        r"""
-        Serialize EnvCTM into a dictionary.
-        """
-        psi = self.psi
-        if isinstance(psi, Peps2Layers):
-            psi = psi.ket
-
-        d = {'class': 'EnvCTM',
-             'psi': psi.save_to_dict(),
-             'data': {}}
-        for site in self.sites():
-            d_local = {dirn: getattr(self[site], dirn).save_to_dict()
-                       for dirn in ['tl', 'tr', 'bl', 'br', 't', 'l', 'b', 'r']}
-            d['data'][site] = d_local
-        return d
-
     def check_corner_bond_dimension(env, disp=False):
 
         dict_bond_dimension = {}
@@ -1135,6 +1136,26 @@ class EnvCTM(Peps):
 
     iterate_ = ctmrg_  #  allow using EnvCtm.iterate_() instead of allow using EnvCtm.ctmrg_()
 
+    def _partial_svd_predict_spec(env,leg0,leg1,sU):
+        # TODO externalize defaults for extending number of singular values to solve for
+        """
+        Used in block-wise partial SVD solvers.
+
+        Based on the projector spectra leg0, leg1, from (previous) projector pair, 
+        suggest number of singular value triples to solve for in each of the blocks.
+
+        Parameters
+        ----------
+        leg0, leg1: yastn.Tensor
+            Projector spectra for the previous projector pair.
+        sU: int 
+            Signature of U in SVD decomposition. See :func:`proj_corners` and :func:`linalg.svd`.
+        """
+        # the projector spectra for projector pair are related by charge conjugation 
+        assert leg0 == leg1.conj(), f"Projector spectrum history mismatch between leg0={leg0} and leg1={leg1}"
+        #
+        l= leg0 if sU == leg0.s else leg1
+        return { t: max(d+10,d*1.1) for t,d in zip(l.t, l.D) }
 
 def decompress_env_1d(data,meta):
     """
@@ -1262,6 +1283,9 @@ def update_2site_projectors_(proj, site, dirn, env, opts_svd, **kwargs):
         return
 
     use_qr = kwargs.get("use_qr", True)
+    psh= kwargs.pop("proj_history", None)
+    svd_predict_spec= lambda s0,p0,s1,p1: kwargs.get('D_block', None) if psh is None else \
+        env._partial_svd_predict_spec(getattr(psh[s0],p0), getattr(psh[s1],p1), opts_svd.get('sU', 1))
 
     tl, tr, bl, br = sites
 
@@ -1288,11 +1312,13 @@ def update_2site_projectors_(proj, site, dirn, env, opts_svd, **kwargs):
     if 'r' in dirn:
         _, r_t = qr(cor_tt, axes=(0, 1)) if use_qr else (None, cor_tt)
         _, r_b = qr(cor_bb, axes=(1, 0)) if use_qr else (None, cor_bb.T)
+        kwargs['D_block'] = svd_predict_spec(tr, 'hrb', br, 'hrt')
         proj[tr].hrb, proj[br].hrt = proj_corners(r_t, r_b, opts_svd=opts_svd, **kwargs)
 
     if 'l' in dirn:
         _, r_t = qr(cor_tt, axes=(1, 0)) if use_qr else (None, cor_tt.T)
         _, r_b = qr(cor_bb, axes=(0, 1)) if use_qr else (None, cor_bb)
+        kwargs['D_block'] = svd_predict_spec(tl, 'hlb', bl, 'hlt')
         proj[tl].hlb, proj[bl].hlt = proj_corners(r_t, r_b, opts_svd=opts_svd, **kwargs)
 
     if ('t' in dirn) or ('b' in dirn):
@@ -1302,11 +1328,13 @@ def update_2site_projectors_(proj, site, dirn, env, opts_svd, **kwargs):
     if 't' in dirn:
         _, r_l = qr(cor_ll, axes=(0, 1)) if use_qr else (None, cor_ll)
         _, r_r = qr(cor_rr, axes=(1, 0)) if use_qr else (None, cor_rr.T)
+        kwargs['D_block'] = svd_predict_spec(tl, 'vtr', tr, 'vtl')
         proj[tl].vtr, proj[tr].vtl = proj_corners(r_l, r_r, opts_svd=opts_svd, **kwargs)
 
     if 'b' in dirn:
         _, r_l = qr(cor_ll, axes=(1, 0)) if use_qr else (None, cor_ll.T)
         _, r_r = qr(cor_rr, axes=(0, 1)) if use_qr else (None, cor_rr)
+        kwargs['D_block'] = svd_predict_spec(bl, 'vbr', br, 'vbl')
         proj[bl].vbr, proj[br].vbl = proj_corners(r_l, r_r, opts_svd=opts_svd, **kwargs)
 
 
@@ -1314,6 +1342,10 @@ def update_1site_projectors_(proj, site, dirn, env, opts_svd, **kwargs):
     r"""
     Calculate new projectors for CTM moves from 4x2 extended corners.
     """
+    psh= kwargs.pop("proj_history", None)
+    svd_predict_spec= lambda s0,p0,s1,p1: kwargs.get('D_block', None) if psh is None else \
+        env._partial_svd_predict_spec(getattr(psh[s0],p0), getattr(psh[s1],p1), opts_svd.get('sU', 1))
+    
     psi = env.psi
     sites = [psi.nn_site(site, d=d) for d in ((0, 0), (0, 1), (1, 0), (1, 1))]
     if None in sites:
@@ -1330,9 +1362,11 @@ def update_1site_projectors_(proj, site, dirn, env, opts_svd, **kwargs):
         r_br, r_bl = regularize_1site_corners(cor_br, cor_bl)
 
     if 'r' in dirn:
+        kwargs['D_block'] = svd_predict_spec(tr, 'hrb', br, 'hrt')
         proj[tr].hrb, proj[br].hrt = proj_corners(r_tr, r_br, opts_svd=opts_svd, **kwargs)
 
     if 'l' in dirn:
+        kwargs['D_block'] = svd_predict_spec(tl, 'hlb', bl, 'hlt')
         proj[tl].hlb, proj[bl].hlt = proj_corners(r_tl, r_bl, opts_svd=opts_svd, **kwargs)
 
     if ('t' in dirn) or ('b' in dirn):
@@ -1344,9 +1378,11 @@ def update_1site_projectors_(proj, site, dirn, env, opts_svd, **kwargs):
         r_tr, r_br = regularize_1site_corners(cor_tr, cor_br)
 
     if 't' in dirn:
+        kwargs['D_block'] = svd_predict_spec(tl, 'vtr', tr, 'vtl')
         proj[tl].vtr, proj[tr].vtl = proj_corners(r_tl, r_tr, opts_svd=opts_svd, **kwargs)
 
     if 'b' in dirn:
+        kwargs['D_block'] = svd_predict_spec(bl, 'vbr', br, 'vbl')
         proj[bl].vbr, proj[br].vbl = proj_corners(r_bl, r_br, opts_svd=opts_svd, **kwargs)
 
 
@@ -1360,17 +1396,26 @@ def regularize_1site_corners(cor_0, cor_1):
     r_1 = tensordot((S @ U_1), Q_1, axes=(1, 1))
     return r_0, r_1
 
+
 def proj_corners(r0, r1, opts_svd, **kwargs):
     r""" Projectors in between r0 @ r1.T corners. """
     rr = tensordot(r0, r1, axes=(1, 1))
     fix_signs= opts_svd.get('fix_signs',True)
     truncation_f= kwargs.get('truncation_f',None)
+    
+    verbosity = opts_svd.get('verbosity', 0)
+    kwargs['verbosity'] = verbosity
+
     if truncation_f is None:
         u, s, v = rr.svd(axes=(0, 1), sU=r0.s[1], fix_signs=fix_signs, **kwargs)
         Smask = truncation_mask(s, **opts_svd)
         u, s, v = Smask.apply_mask(u, s, v, axes=(-1, 0, 0))
     else:
         u, s, v = rr.svd_with_truncation(axes=(0, 1), sU=r0.s[1], mask_f=truncation_f, **kwargs)
+    
+    if verbosity>2:
+        fname = sys._getframe().f_code.co_name
+        logger.info(f"{fname} S {s.get_legs(0)}")
 
     rs = s.rsqrt()
     p0 = tensordot(r1, (rs @ v).conj(), axes=(0, 1)).unfuse_legs(axes=0)


### PR DESCRIPTION
i) Refactoring of SVD policies
ii) extending CTMRG to reuse information from projectors in previous step. Necessary for block-wise partial SVD solvers
    to estimate number of singular triples to compute in each sector.
iii) save_for_backward for all tensors when using fixed-point gradient

SVD policies are:
* 'fullrank'
* 'lowrank' : default policy for block-wise partial SVD)
   - for numpy backend defaults to block-wise partial SVD provided by scipy's svds. First trying ARPACK followed by PROPACK as a backup [previous behaviour]
   - for torch defaults to randomized SVD provided by torch.svd_lowrank
* 'randomized' : randomized SVD 
   - not supported on numpy backend
* 'block_arpack' and 'block_propack' : block-wise solvers using scipy's  svds
* 'krylov' : global solver using scipy's svds with matrix-vector products making use of explicit block structure (symmetries). Here, we solve over all blocks simultaneously


             