### PR TITLE
fix validation for add_leg using int as charge t for nsym=1

### DIFF
--- a/yastn/tensor/_single.py
+++ b/yastn/tensor/_single.py
@@ -408,7 +408,7 @@ def add_leg(a, axis=-1, s=-1, t=None, leg=None) -> yastn.Tensor:
     if t is None:
         t = a.config.sym.add_charges(a.struct.n, signatures=(-1,), new_signature=s)
     else:
-        if (isinstance(t, int) and nsym != 1) or len(t) != nsym:
+        if (isinstance(t, int) and nsym != 1) or (hasattr(t, '__len__') and len(t) != nsym):
             raise YastnError('len(t) does not match the number of symmetry charges.')
         t = a.config.sym.add_charges(t, signatures=(s,), new_signature=s)
 


### PR DESCRIPTION
Issue:

```
>>> import yastn
>>> cfg= yastn.make_config(sym=yastn.sym.sym_U1)
>>> L= yastn.Leg(cfg, s=1, t=(-1,0,1), D=(1,1,1))
>>> T= yastn.zeros(cfg, legs=[L,L.conj()])
>>> T.add_leg(s=1, t=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/urza/Projects/scratch/tn-torch_dev/yastn/yastn/tensor/_single.py", line 411, in add_leg
    if (isinstance(t, int) and nsym != 1) or len(t) != nsym:
                                             ^^^^^^
TypeError: object of type 'int' has no len()
```

This should pass but the second clause is tested and fails on t (being just int) not having __len__