### PR TITLE
resolve_ops when calling to_dict

### DIFF
--- a/tests/tensor/test_to_dict_from_dict.py
+++ b/tests/tensor/test_to_dict_from_dict.py
@@ -19,7 +19,18 @@ import pytest
 import yastn
 
 
-def test_to_from_dict(config_kwargs):
+def are_identical_tensors(a, b):
+    da, db = a.__dict__, b.__dict__
+    assert da.keys() == db.keys()
+    for k in da:
+        if k != '_data':
+            assert da[k] == db[k]
+    assert type(a.data) == type(b.data)
+    assert np.allclose(a.to_numpy(), b.to_numpy())
+
+
+@pytest.mark.parametrize("resolve_ops", [True,False])
+def test_to_from_dict(resolve_ops, config_kwargs):
     config = yastn.make_config(sym='U1', **config_kwargs)
     legs = [yastn.Leg(config, s=1, t=(0, 1, 2), D= (3, 5, 2)),
             yastn.Leg(config, s=-1, t=(0, 1, 3), D= (1, 2, 3)),
@@ -31,7 +42,7 @@ def test_to_from_dict(config_kwargs):
     a = a.fuse_legs(axes=(0, (1, 2)), mode='meta')
 
     for level, ind in zip([0, 1, 2], [False, False, True]):
-        d = a.to_dict(level=level)
+        d = a.to_dict(level=level,resolve_ops=resolve_ops)
         b = yastn.Tensor.from_dict(d)
         assert b.is_consistent()
 
@@ -50,16 +61,6 @@ def test_to_from_dict(config_kwargs):
         # assert yastn.are_independent(b, c) == ind  # for numpy
         # # assert yastn.are_independent(b, c) == False  # for torch
         # torch.as_tensor and numpy.array have different behavior in creating a copy
-
-
-def are_identical_tensors(a, b):
-    da, db = a.__dict__, b.__dict__
-    assert da.keys() == db.keys()
-    for k in da:
-        if k != '_data':
-            assert da[k] == db[k]
-    assert type(a.data) == type(b.data)
-    assert np.allclose(a.to_numpy(), b.to_numpy())
 
 
 def test_to_dict_embed(config_kwargs):

--- a/yastn/tensor/_output.py
+++ b/yastn/tensor/_output.py
@@ -32,7 +32,7 @@ from .._split_combine_dict import split_data_and_meta, combine_data_and_meta
 __all__ = ['save_to_dict', 'save_to_hdf5', 'requires_grad']
 
 
-def to_dict(a, level=2, meta=None) -> dict:
+def to_dict(a, level=2, meta=None, resolve_ops=False) -> dict:
     r"""
     Serialize YASTN tensor to a dictionary containing all the information needed to recreate the tensor.
     Complementary function is :meth:`yastn.Tensor.from_dict` or a general :meth:`yastn.from_dict`.
@@ -63,6 +63,9 @@ def to_dict(a, level=2, meta=None) -> dict:
         that allows using external matrix-free methods, such as :func:`eigs` implemented in SciPy.
         See example at :ref:`examples/tensor/decomposition:combining with scipy.sparse.linalg.eigs`.
     """
+    if resolve_ops:
+        return a.consume_transpose().to_dict(level=level, meta=meta, resolve_ops=False)        
+    
     if level >= 1:
         config = a.config._asdict()
         config['sym'] = config['sym'].SYM_ID

--- a/yastn/tn/fpeps/_geometry.py
+++ b/yastn/tn/fpeps/_geometry.py
@@ -486,7 +486,7 @@ class Lattice():
         """ Allows iterating over lattice sites like in dict. """
         return ((site, self[site]) for site in self.sites())
 
-    def to_dict(self, level=2) -> dict:
+    def to_dict(self, level=2, resolve_ops=False) -> dict:
         """
         Serialize Lattice or Peps into a dictionary.
         Complementary functions are :meth:`yastn.Lattice.from_dict` and :meth:`yastn.Peps.from_dict`,
@@ -496,7 +496,7 @@ class Lattice():
         return {'type': type(self).__name__,
                 'dict_ver': 1,
                 'geometry': self.geometry.to_dict(),
-                'site_data': {k: v.to_dict(level=level) for k, v in self._site_data.items() if v is not None}}
+                'site_data': {k: v.to_dict(level=level, resolve_ops=resolve_ops) for k, v in self._site_data.items() if v is not None}}
 
     @classmethod
     def from_dict(cls, d, config=None):

--- a/yastn/tn/fpeps/_peps.py
+++ b/yastn/tn/fpeps/_peps.py
@@ -306,18 +306,18 @@ class Peps2Layers():
         return Peps2Layers(ket=self.ket.to(device=device, dtype=dtype, **kwargs),
                            bra=self.bra.to(device=device, dtype=dtype, **kwargs) if not self.bra_is_ket else None)
 
-    def to_dict(self, level=2) -> dict:
+    def to_dict(self, level=2, resolve_ops=False) -> dict:
         r"""
         Serialize Peps2Layers to a dictionary.
         Complementary function is :meth:`yastn.Peps2Layers.from_dict` or a general :meth:`yastn.from_dict`.
         See :meth:`yastn.Tensor.to_dict` for further description.
         """
-        if self._bra is None:
-            return self.ket.to_dict(level=level)  # 2 layers would be reintroduced by environment functions
+        if self.ket is None:
+            return self.bra.to_dict(level=level, resolve_ops=resolve_ops)  # 2 layers would be reintroduced by environment functions
         return {'type': type(self).__name__,
              'dict_ver': 1,
-             'bra': self.bra.to_dict(level=level),
-             'ket': self.ket.to_dict(level=level)}
+             'bra': self.bra.to_dict(level=level, resolve_ops=resolve_ops),
+             'ket': self.ket.to_dict(level=level, resolve_ops=resolve_ops)}
 
     @classmethod
     def from_dict(cls, d, config=None):

--- a/yastn/tn/fpeps/envs/_env_dataclasses.py
+++ b/yastn/tn/fpeps/envs/_env_dataclasses.py
@@ -78,13 +78,13 @@ class dataclasses_common():
                 tests.append(ta.are_independent(tb) == independent)
         return all(tests)
 
-    def to_dict(self, level=2):
+    def to_dict(self, level=2, resolve_ops=False):
         """ Return a dictionary representation of the object. """
         d = {'type': type(self).__name__,
              'dict_ver': 1}
         for k in fields(self):
             if getattr(self, k.name) is not None:
-                d[k.name] = getattr(self, k.name).to_dict(level=level)
+                d[k.name] = getattr(self, k.name).to_dict(level=level, resolve_ops=resolve_ops)
         return d
 
     @classmethod


### PR DESCRIPTION
When serializing complex objects to_dict, optionally force resolution of delayed ops on tensors, as i.e. transpose,
throughout the structures