### PR TITLE
Refactor leg first merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: setup pytorch
         run: |
-            pip install torch==2.9 --index-url https://download.pytorch.org/whl/cpu
+            pip install torch==2.10 --index-url https://download.pytorch.org/whl/cpu
 
       - name: static analysis flake8
         run: |
@@ -153,7 +153,7 @@ jobs:
             python_v: '3.12'
             numpy_v: '2.4'
             scipy_v: '1.16'
-            torch_v: '2.9'
+            torch_v: '2.10'
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/tests/tensor/test_checkpoint_multi_device.py
+++ b/tests/tensor/test_checkpoint_multi_device.py
@@ -386,3 +386,183 @@ def test_backward_checkpoint_multidev_multi_index(config_kwargs, devices):
     result.norm().backward()
 
     _check_grad([A, B, C], [ref_A, ref_B, ref_C], label="ckpt+multidev-multi-idx")
+
+
+# ---------------------------------------------------------------------------
+# Workers>1 per device: single-device (intra-device) and packed across two
+# devices. Two-index unroll -> up to 4 combos.
+# ---------------------------------------------------------------------------
+@multidev_test
+@pytest.mark.parametrize("n_dev,workers", [
+    (1, 2),
+    (1, 3),
+    pytest.param(2, 2, marks=pytest.mark.skipif(
+        "config.getoption('--devices') is None or "
+        "len([d for d in config.getoption('--devices').split(',') if d.strip()]) < 2",
+        reason="needs >=2 devices")),
+])
+def test_multidev_workers_per_device(config_kwargs, devices, n_dev, workers):
+    """>1 worker per device — round-robin combo assignment + shared per-device IPC replica; on n_dev device(s) with a two-index unroll."""
+    cfg = yastn.make_config(sym='U1', **config_kwargs)
+    dev = devices[:n_dev]
+    leg_i = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 2))
+    leg_j = yastn.Leg(cfg, s=1, t=(0, 1), D=(3, 3))
+    leg_k = yastn.Leg(cfg, s=1, t=(0, 1), D=(3, 3))
+    leg_l = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 2))
+    A = yastn.rand(config=cfg, legs=[leg_i, leg_j.conj()], n=0)
+    B = yastn.rand(config=cfg, legs=[leg_j, leg_k.conj()], n=0)
+    C = yastn.rand(config=cfg, legs=[leg_k, leg_l.conj()], n=0)
+
+    path, _ = yastn.get_contraction_path(
+        A, ('i', 'j'), B, ('j', 'k'), C, ('k', 'l'), ('i', 'l'))
+    expected = yastn.ncon([A, B, C], [[-1, 1], [1, 2], [2, -2]])
+
+    result = yastn.contract_with_unroll(
+        A, ('i', 'j'), B, ('j', 'k'), C, ('k', 'l'), ('i', 'l'),
+        unroll={'j': yastn.make_sliced_legs(leg_j),
+                'k': yastn.make_sliced_legs(leg_k)},
+        optimize=path,
+        checkpoint_loop=True, devices=dev, mp_workers_per_device=workers,
+    )
+    assert result.device == cfg.default_device
+    assert float(yastn.norm(result - expected)) < tol
+
+
+# ---------------------------------------------------------------------------
+# 16. Backward: workers>1 per device, grads vs single-device reference
+# ---------------------------------------------------------------------------
+@multidev_test
+def test_backward_multidev_workers_per_device(config_kwargs, devices):
+    """Backward with two workers per device: gradients match the single-device ncon reference."""
+    cfg = yastn.make_config(sym='U1', **config_kwargs)
+    leg_i = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 2))
+    leg_j = yastn.Leg(cfg, s=1, t=(0, 1), D=(3, 3))
+    leg_k = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 2))
+    leg_l = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 2))
+    A = yastn.rand(config=cfg, legs=[leg_i, leg_j.conj()], n=0)
+    B = yastn.rand(config=cfg, legs=[leg_j, leg_k.conj()], n=0)
+    C = yastn.rand(config=cfg, legs=[leg_k, leg_l.conj()], n=0)
+
+    ref_A, ref_B, ref_C = A.clone(), B.clone(), C.clone()
+    ref_A.requires_grad_(True)
+    ref_B.requires_grad_(True)
+    ref_C.requires_grad_(True)
+    ref_result = yastn.ncon([ref_A, ref_B, ref_C], [[-1, 1], [1, 2], [2, -2]])
+    ref_result.norm().backward()
+
+    A.requires_grad_(True)
+    B.requires_grad_(True)
+    C.requires_grad_(True)
+    path, _ = yastn.get_contraction_path(
+        A, ('i', 'j'), B, ('j', 'k'), C, ('k', 'l'), ('i', 'l'))
+    result = yastn.contract_with_unroll(
+        A, ('i', 'j'), B, ('j', 'k'), C, ('k', 'l'), ('i', 'l'),
+        unroll={'j': yastn.make_sliced_legs(leg_j)}, optimize=path,
+        checkpoint_loop=True, devices=devices, mp_workers_per_device=2,
+    )
+    result.norm().backward()
+
+    _check_grad([A, B, C], [ref_A, ref_B, ref_C], label="workers-per-device backward")
+
+
+# ---------------------------------------------------------------------------
+# 17. Fermionic (Z2 + swap gate): scalar contraction + unroll + multi-device
+# ---------------------------------------------------------------------------
+@multidev_test
+def test_multidev_fermionic_swap(config_kwargs, devices):
+    """Fermionic Z2 contraction with a swap gate, dispatched multi-device (adapted from the single-device swap-diagram tests)."""
+    cfg = yastn.make_config(sym='Z2', fermionic=True, **config_kwargs)
+    l = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 3))
+    lc = l.conj()
+    a = yastn.rand(config=cfg, legs=[l, lc])
+    b = yastn.rand(config=cfg, legs=[l, lc])
+    ref = yastn.ncon([a, b], ((1, 2), (2, 1)), swap=[(1, 2)])
+    path, _ = yastn.get_contraction_path(a, ('p', 'q'), b, ('q', 'p'), ())
+    result = yastn.contract_with_unroll(
+        a, ('p', 'q'), b, ('q', 'p'), (),
+        optimize=path, swap=[('p', 'q')],
+        unroll={'p': yastn.make_sliced_legs(l)},
+        checkpoint_loop=True, devices=devices, mp_workers_per_device=1,
+    )
+    assert float(yastn.norm(result - ref)) < tol
+
+
+# ---------------------------------------------------------------------------
+# 18. Multi-component symmetry (U1xU1): chain + output legs + unroll + multidev
+# ---------------------------------------------------------------------------
+@multidev_test
+def test_multidev_multisym_u1xu1(config_kwargs, devices):
+    """Two-component symmetry (U1xU1): derived output structs carry length-2 charges."""
+    cfg = yastn.make_config(sym='U1xU1', **config_kwargs)
+    leg_i = yastn.Leg(cfg, s=1, t=[(0, 0), (1, 1)], D=(2, 2))
+    leg_j = yastn.Leg(cfg, s=1, t=[(0, 0), (1, 1)], D=(3, 3))
+    leg_k = yastn.Leg(cfg, s=1, t=[(0, 0), (1, 1)], D=(2, 2))
+    leg_l = yastn.Leg(cfg, s=1, t=[(0, 0), (1, 1)], D=(2, 2))
+    A = yastn.rand(config=cfg, legs=[leg_i, leg_j.conj()], n=(0, 0))
+    B = yastn.rand(config=cfg, legs=[leg_j, leg_k.conj()], n=(0, 0))
+    C = yastn.rand(config=cfg, legs=[leg_k, leg_l.conj()], n=(0, 0))
+    path, _ = yastn.get_contraction_path(
+        A, ('i', 'j'), B, ('j', 'k'), C, ('k', 'l'), ('i', 'l'))
+    expected = yastn.ncon([A, B, C], [[-1, 1], [1, 2], [2, -2]])
+    result = yastn.contract_with_unroll(
+        A, ('i', 'j'), B, ('j', 'k'), C, ('k', 'l'), ('i', 'l'),
+        unroll={'j': yastn.make_sliced_legs(leg_j)}, optimize=path,
+        checkpoint_loop=True, devices=devices, mp_workers_per_device=1,
+    )
+    assert result.device == cfg.default_device
+    assert float(yastn.norm(result - expected)) < tol
+
+
+# ===========================================================================
+# ---------------------------------------------------------------------------
+# 19. per_combo_path=True + multi-device (dim_overrides through the pool)
+# ---------------------------------------------------------------------------
+@multidev_test
+def test_multidev_per_combo_path(config_kwargs, devices):
+    """per_combo_path=True: per-combo path selection + dim_overrides routed through the pool (asymmetric dims make it non-trivial)."""
+    cfg = yastn.make_config(sym='U1', **config_kwargs)
+    leg_i = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 3))
+    leg_j = yastn.Leg(cfg, s=1, t=(0, 1), D=(4, 5))
+    leg_k = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 3))
+    leg_l = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 2))
+    A = yastn.rand(config=cfg, legs=[leg_i, leg_j.conj()], n=0)
+    B = yastn.rand(config=cfg, legs=[leg_j, leg_k.conj()], n=0)
+    C = yastn.rand(config=cfg, legs=[leg_k, leg_l.conj()], n=0)
+    path, _ = yastn.get_contraction_path(
+        A, ('i', 'j'), B, ('j', 'k'), C, ('k', 'l'), ('i', 'l'))
+    expected = yastn.ncon([A, B, C], [[-1, 1], [1, 2], [2, -2]])
+    result = yastn.contract_with_unroll(
+        A, ('i', 'j'), B, ('j', 'k'), C, ('k', 'l'), ('i', 'l'),
+        unroll={'j': yastn.make_sliced_legs(leg_j)}, optimize=path,
+        per_combo_path=True,
+        checkpoint_loop=True, devices=devices, mp_workers_per_device=1,
+    )
+    assert result.device == cfg.default_device
+    assert float(yastn.norm(result - expected)) < tol
+
+
+# ---------------------------------------------------------------------------
+# 20. Fused OUTPUT leg (meta + hard) + unroll + multi-device. The from-legs
+#     derivation must gather and rebuild the fused Leg via zeros so it matches
+#     the worker partials (hard fusion covers review finding [1]).
+# ---------------------------------------------------------------------------
+@multidev_test
+@pytest.mark.parametrize("mode", ['meta', 'hard'])
+def test_multidev_fused_output_leg(config_kwargs, devices, mode):
+    """A fused leg survives to the output; the from-legs derivation rebuilds it via zeros to match the worker partials."""
+    cfg = yastn.make_config(sym='U1', **config_kwargs)
+    leg_i1 = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 2))
+    leg_i2 = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 2))
+    leg_j = yastn.Leg(cfg, s=1, t=(0, 1), D=(3, 3))
+    leg_k = yastn.Leg(cfg, s=1, t=(0, 1), D=(2, 2))
+    A = yastn.rand(config=cfg, legs=[leg_i1, leg_i2, leg_j.conj()], n=0)
+    B = yastn.rand(config=cfg, legs=[leg_j, leg_k.conj()], n=0)
+    Af = A.fuse_legs(axes=((0, 1), 2), mode=mode)  # legs: (i=(i1,i2) fused, j)
+    path, _ = yastn.get_contraction_path(Af, ('i', 'j'), B, ('j', 'k'), ('i', 'k'))
+    expected = yastn.ncon([Af, B], [[-1, 1], [1, -2]])
+    result = yastn.contract_with_unroll(
+        Af, ('i', 'j'), B, ('j', 'k'), ('i', 'k'),
+        unroll={'j': yastn.make_sliced_legs(leg_j)}, optimize=path,
+        checkpoint_loop=True, devices=devices, mp_workers_per_device=1,
+    )
+    assert float(yastn.norm(result - expected)) < tol

--- a/yastn/_mp_logging.py
+++ b/yastn/_mp_logging.py
@@ -72,7 +72,7 @@ def snapshot_logger_levels():
     Handed to spawn workers alongside the root level so they replay the
     parent's *per-logger* configuration on top of the root level -- e.g. a
     single module bumped to ``DEBUG`` (``--log_oe_path`` raises
-    ``yastn.yastn.tensor.oe_blocksparse``) becomes visible in workers too,
+    ``yastn.tensor.oe_blocksparse``) becomes visible in workers too,
     while everything else stays at the root level. Returns a plain dict
     (picklable for ``Process`` args).
     """

--- a/yastn/backend/backend_np.py
+++ b/yastn/backend/backend_np.py
@@ -626,7 +626,7 @@ def apply_mask(Adata, mask, meta, Dsize, axis, a_ndim):
     slc2 = (slice(None),) * (a_ndim - (axis + 1))
     newdata = np.empty(Dsize, dtype=Adata.dtype)
     for sln, Dn, sla, Da, tm in meta:
-        slcs = slc1 + (mask[*tm],) + slc2
+        slcs = slc1 + (mask[tuple(tm)],) + slc2
         newdata[slice(*sln)].reshape(Dn)[:] = Adata[slice(*sla)].reshape(Da)[slcs]
     return newdata
 
@@ -636,7 +636,7 @@ def embed_mask(Adata, mask, meta, Dsize, axis, a_ndim):
     slc2 = (slice(None),) * (a_ndim - (axis + 1))
     newdata = np.zeros(Dsize, dtype=Adata.dtype)
     for sln, Dn, sla, Da, tm in meta:
-        slcs = slc1 + (mask[*tm],) + slc2
+        slcs = slc1 + (mask[tuple(tm)],) + slc2
         newdata[slice(*sln)].reshape(Dn)[slcs] = Adata[slice(*sla)].reshape(Da)
     return newdata
 

--- a/yastn/backend/backend_np.py
+++ b/yastn/backend/backend_np.py
@@ -287,6 +287,11 @@ def svd_lowrank(data, meta, sizes, **kwargs):
     return svds_scipy(data, meta, sizes, None, 'arpack', **kwargs)
 
 
+def nonzero_blocks(data, slcs):
+    """ Per-slice flags: whether data[slice] has any nonzero element. """
+    return tuple(bool(data[slice(*sl)].any()) for sl in slcs)
+
+
 def dtype_to_complex(data):
     """ type promotion to complex. """
     tmp = 1j * np.array(1, dtype=data.dtype)
@@ -464,7 +469,7 @@ def eigh(data, meta=None, sizes=(1, 1)):
             try:
                 S, U = scipy.linalg.eigh(data[slice(*slo)].reshape(Do))
             except scipy.linalg.LinAlgError:  # pragma: no cover
-                S, U = np.linalg.eigh(data[slice(*x['slo'])].reshape(Do))
+                S, U = np.linalg.eigh(data[slice(*slo)].reshape(Do))
             Sdata[slice(*slS)] = S
             Udata[slice(*slU)].reshape(DU)[:] = U
         return Sdata, Udata

--- a/yastn/backend/backend_torch.py
+++ b/yastn/backend/backend_torch.py
@@ -40,7 +40,7 @@ __all__= ['DTYPE', 'get_dtype', 'get_yastn_dtype',
     'expm', 'first_element', 'item', 'sum_elements', 'norm', 'entropy',
     'zeros', 'ones', 'rand', 'to_tensor', 'to_mask', 'square_matrix_from_dict',
     'trace', 'rsqrt', 'reciprocal', 'exp', 'sqrt', 'absolute', 'permute_dims',
-    'fix_svd_signs', 'svdvals', 'svd_lowrank', 'svd', 'svd_randomized', 'svds_scipy',
+    'fix_svd_signs', 'svdvals', 'svd_lowrank', 'svd', 'svd_randomized', 'svds_scipy', 'nonzero_blocks',
     'eigh', 'qr', 'pinv', 'eig', 'eigh_lowrank', 'eigvals',
     'argsort', 'argsort_which', 'argmax', 'flip', 'allclose',
     'add', 'sub', 'apply_mask', 'vdot', 'diag_1dto2d', 'diag_2dto1d',
@@ -313,6 +313,11 @@ def svd_lowrank(data, meta, sizes, **kwargs):
     return svds_scipy(data, meta, sizes, solver='arpack', **kwargs)
 
 
+def nonzero_blocks(data, slcs):
+    """ Per-slice flags: whether data[slice] has any nonzero element. """
+    return tuple(bool(data[slice(*sl)].any()) for sl in slcs)
+
+
 def dtype_to_complex(data):
     """ type promotion to complex. """
     tmp = 1j * torch.tensor(1, dtype=data.dtype)
@@ -433,6 +438,7 @@ def eigh_lowrank(data, meta, sizes, thresh=None, **kwargs):
     # TODO cupyx implementation of eigsh for GPU
     import numpy as np
     import scipy
+    from .backend_np import argsort_which as np_argsort_which
 
     _which_map= {'LM': 'LM', 'SM': 'SM', 'LR': 'LA',  'SR': 'SA'}
     _which = kwargs.get('which', 'LM')
@@ -460,7 +466,7 @@ def eigh_lowrank(data, meta, sizes, thresh=None, **kwargs):
         # sort in case of non-default order
         # see https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html
         if not (_which in ['SR'] and  kwargs.get("return_eigenvectors", True)):
-            arg_b = argsort_which(S, _which)
+            arg_b = np_argsort_which(S, _which)  # S, U are numpy here
             S,U = S[arg_b[:k]], U[:,arg_b[:k]]
         else:
             S,U = S[:k], U[:,:k]

--- a/yastn/tensor/_auxiliary.py
+++ b/yastn/tensor/_auxiliary.py
@@ -92,7 +92,7 @@ def _compress_slices(meta):
     c2 = s2 // 2
     slcs = meta.reshape(s1, c2, 2).transpose((1, 0, 2))
     inds = np.any(slcs[:, 1:, 0] != slcs[:, :-1, 1], axis=0)
-    mask = np.ones((s1, 2), dtype=np.bool)
+    mask = np.ones((s1, 2), dtype=bool)
     mask[1:, 0] = inds
     mask[:-1, 1] = inds
     mask = mask.reshape(2 * s1)

--- a/yastn/tensor/_contractions.py
+++ b/yastn/tensor/_contractions.py
@@ -291,8 +291,8 @@ def _meta_tensordot_fc(sym, struct_a, struct_b):
     unique_a, inv_a, count_a = np.unique(bl_a.t[:, -1, :], return_inverse=True, return_counts=True, axis=0)
     unique_b, inv_b, count_b = np.unique(bl_b.t[:,  0, :], return_inverse=True, return_counts=True, axis=0)
     assert np.array_equal(unique_a, unique_b), "Sanity check. Contact developers."
-    arg_a = np.argsort(inv_a, stable=True)
-    arg_b = np.argsort(inv_b, stable=True)
+    arg_a = np.argsort(inv_a, kind='stable')
+    arg_b = np.argsort(inv_b, kind='stable')
     #
     ind_a, ind_b = _indices_from_counts(count_a, count_b)
     ind_a = arg_a[ind_a]

--- a/yastn/tensor/_oe_blocksparse_mp.py
+++ b/yastn/tensor/_oe_blocksparse_mp.py
@@ -57,23 +57,32 @@ def _deserialize_yastn(d, config):
     return Tensor.from_dict(d, config=config)
 
 
+def _freeze(obj):
+    """Recursively turn dicts and lists into hashable tuples."""
+    if isinstance(obj, dict):
+        return tuple((k, _freeze(v)) for k, v in sorted(obj.items()))
+    if isinstance(obj, (list, tuple)):
+        return tuple(_freeze(v) for v in obj)
+    return obj
+
+
 def _build_cache_key(input_dicts, unroll, ig_list, out_ig, optimize, swap, per_combo_path):
     """Stable key for the assembly-info cache. ``per_combo_path`` participates
     because cached entries carry ``dim_overrides_per_combo`` only when it was
     True at insertion time; reusing a False-time entry for a True-time call
-    would leave workers with a missing payload."""
-    input_keys = []
-    for d in input_dicts:
-        st = d['struct']
-        if isinstance(st, dict):
-            input_keys.append((st.get('s'), tuple(map(tuple, st.get('t', ()))),
-                               tuple(map(tuple, st.get('D', ()))), st.get('n')))
-        else:
-            input_keys.append((st.s, st.t, st.D, st.n))
+    would leave workers with a missing payload.
+
+    Each input contributes all of its serialized metadata (leg-first struct,
+    pending transpose, fusion history) except the data buffer — all of it
+    determines the contraction's block structure, so any difference must miss
+    the cache."""
+    input_keys = tuple(
+        _freeze({k: v for k, v in d.items() if k != 'data'}) for d in input_dicts
+    )
     unroll_key = tuple(sorted(
         (str(k), tuple((sl.t, sl.D) for sl in sls)) for k, sls in unroll.items()
     ))
-    return (tuple(input_keys), unroll_key,
+    return (input_keys, unroll_key,
             tuple(tuple(ig) for ig in ig_list), tuple(out_ig),
             str(optimize), str(swap), bool(per_combo_path))
 
@@ -390,12 +399,16 @@ class _MultiprocSlicedUnrollFunction(torch.autograd.Function):
 
         n_active = sum(1 for a in worker_assignments if a)
         per_worker_partials = []  # list of {key: serialized yastn dict}
-        for _ in range(n_active):
+        while len(per_worker_partials) < n_active:
             msg = pool.res_q.get()
-            if msg[0] != 'forward_done':
+            kind, _rank, _txn, payload = msg
+            if _txn != txn_id:
+                # leftover from an earlier transaction that raised mid-drain
+                log.warning("discarding stale %s message from txn %s", kind, _txn)
+                continue
+            if kind != 'forward_done':
                 raise RuntimeError(f"worker forward failed: {msg}")
-            _, _rank, _txn, partials_dict = msg
-            per_worker_partials.append(partials_dict)
+            per_worker_partials.append(payload)
 
         if per_key_struct is None:
             # Cache-miss path: workers returned RAW partials. Merge via yastn '+'
@@ -550,12 +563,16 @@ class _MultiprocSlicedUnrollFunction(torch.autograd.Function):
 
         n_active = sum(1 for a in worker_assignments if a)
         per_worker_input_grads = []
-        for _ in range(n_active):
+        while len(per_worker_input_grads) < n_active:
             msg = pool.res_q.get()
-            if msg[0] != 'backward_done':
+            kind, _rank, _txn, payload = msg
+            if _txn != txn_id:
+                # leftover from an earlier transaction that raised mid-drain
+                log.warning("discarding stale %s message from txn %s", kind, _txn)
+                continue
+            if kind != 'backward_done':
                 raise RuntimeError(f"worker backward failed: {msg}")
-            _, _rank, _txn, grads = msg
-            per_worker_input_grads.append(grads)
+            per_worker_input_grads.append(payload)
 
         # Sum per-input grads across workers. Workers may live on different
         # GPUs, so gather each contribution to the original (input) device

--- a/yastn/tensor/_oe_blocksparse_mp.py
+++ b/yastn/tensor/_oe_blocksparse_mp.py
@@ -20,6 +20,8 @@ Supports both:
 """
 import atexit
 import logging
+import queue as _queue
+from collections import OrderedDict
 import torch
 import torch.multiprocessing as _mp
 
@@ -29,6 +31,14 @@ log = logging.getLogger(__name__)
 # Module-level pool registry: (devices_tuple, mp_workers_per_device,
 # config_descriptor_hash) -> _PersistentWorkerPool
 _pool_registry = {}
+
+# Bound the per-pool assembly-recipe cache so long, shape-evolving runs don't
+# accumulate one entry per distinct structure without limit (LRU eviction).
+_STRUCT_CACHE_MAXSIZE = 512
+
+# How often a result-drain waits before checking whether an assigned worker has
+# died without posting (turns an infinite res_q.get() hang into an error).
+_WORKER_POLL_SECONDS = 30.0
 
 
 def _config_descriptor(config):
@@ -57,28 +67,32 @@ def _deserialize_yastn(d, config):
     return Tensor.from_dict(d, config=config)
 
 
-def _freeze(obj):
-    """Recursively turn dicts and lists into hashable tuples."""
-    if isinstance(obj, dict):
-        return tuple((k, _freeze(v)) for k, v in sorted(obj.items()))
-    if isinstance(obj, (list, tuple)):
-        return tuple(_freeze(v) for v in obj)
-    return obj
+def _struct_identity(t):
+    """Hashable, allocation-free structural fingerprint of a tensor under the
+    leg-first model: its ``struct`` (legs / n / isdiag), any pending transpose,
+    and its meta/hard fusion histories. These are exactly the fields ``to_dict``
+    compares for structural equality, and each is already a hashable
+    NamedTuple/tuple in memory (``get_blocks`` and the ``_meta_*`` routines
+    lru_cache on ``struct`` / ``hfs``), so no ``to_dict``/serialization
+    round-trip is needed to key on structure.
+
+    Lossless: two tensors share this identity iff they are structurally
+    identical, so a dict/lru keyed on it cannot false-hit — unlike the earlier
+    key, which projected the serialized struct down and could collide."""
+    return (t.struct, t.trans, t.hfs, t.mfs)
 
 
-def _build_cache_key(input_dicts, unroll, ig_list, out_ig, optimize, swap, per_combo_path):
-    """Stable key for the assembly-info cache. ``per_combo_path`` participates
-    because cached entries carry ``dim_overrides_per_combo`` only when it was
-    True at insertion time; reusing a False-time entry for a True-time call
-    would leave workers with a missing payload.
+def _build_cache_key(tensors, unroll, ig_list, out_ig, optimize, swap, per_combo_path):
+    """Stable, cheap key for the assembly-info cache, built from in-memory
+    hashable metadata (no ``to_dict``/``_freeze`` round-trip). ``per_combo_path``
+    participates because cached entries carry ``dim_overrides_per_combo`` only
+    when it was True at insertion time; reusing a False-time entry for a
+    True-time call would leave workers with a missing payload.
 
-    Each input contributes all of its serialized metadata (leg-first struct,
-    pending transpose, fusion history) except the data buffer — all of it
-    determines the contraction's block structure, so any difference must miss
-    the cache."""
-    input_keys = tuple(
-        _freeze({k: v for k, v in d.items() if k != 'data'}) for d in input_dicts
-    )
+    Each input contributes its full leg-first structural fingerprint, so any
+    difference in leg structure, pending transpose or fusion history misses the
+    cache. Config/sym are fixed per pool, so they need not enter the key."""
+    input_keys = tuple(_struct_identity(t) for t in tensors)
     unroll_key = tuple(sorted(
         (str(k), tuple((sl.t, sl.D) for sl in sls)) for k, sls in unroll.items()
     ))
@@ -87,26 +101,114 @@ def _build_cache_key(input_dicts, unroll, ig_list, out_ig, optimize, swap, per_c
             str(optimize), str(swap), bool(per_combo_path))
 
 
-def _compute_common_legs_axes(partials_dict, unroll, out_ig):
-    """Return (common_legs_axes, ndim_out) for yastn_block of partials, or
-    (None, None) if no output-unrolled labels (single-key case).
-    Mirrors the assembly logic in _contract_with_sliced_unroll.
-    """
-    out_ig_list = list(out_ig)
-    blocked_axes = sorted(
-        out_ig_list.index(u) for u in unroll.keys() if u in out_ig_list
-    )
-    if not blocked_axes:
-        return None, None
-    if not partials_dict:
-        return None, None
-    first_partial = next(iter(partials_dict.values()))
-    ndim_out = first_partial.ndim_n
-    return [ax for ax in range(ndim_out) if ax not in blocked_axes], ndim_out
-
-
 def _meta_only(yastn_dict):
     return {k: v for k, v in yastn_dict.items() if k != 'data'}
+
+
+def _zeros_meta(config, legs, n):
+    """Serialized ``to_dict(level=1)`` metadata (minus ``data``) for
+    ``zeros(legs, n)`` WITHOUT allocating the full block-data buffer.
+
+    ``zeros`` -> ``_fill_tensor`` computes the struct via ``get_blocks`` (pure
+    metadata) and only then allocates ``_init_block(bl.size)``. We stop before
+    that allocation: the ``Tensor`` shell already carries a 1-element placeholder
+    buffer, so a large output costs no full-size zero buffer per cache miss."""
+    from . import Tensor
+    from ._auxiliary import _unpack_legs, get_blocks
+    ulegs, mfs = _unpack_legs(legs)
+    s = tuple(lg.s for lg in ulegs)
+    hfs = tuple(lg.hf for lg in ulegs)
+    a = Tensor(config=config, s=s, n=n, isdiag=False, mfs=mfs, hfs=hfs)
+    legs_tD = tuple(lb._replace(t=lg.t, D=lg.D) for lb, lg in zip(a.struct.legs, ulegs))
+    bl = get_blocks(config.sym, a.struct._replace(legs=legs_tD))
+    a.struct = bl.struct
+    d = _meta_only(a.to_dict(level=1))
+    d['size'] = bl.size  # to_dict read size from the 1-element placeholder buffer
+    return d
+
+
+def _derive_output_structs(tensors, ig_list, out_ig, unroll, surviving, config):
+    """Derive ``(per_key_struct, full_struct, common_legs_axes)`` from input
+    legs alone — NO block contraction on data.
+
+    In a tensor-network contraction the output legs are exactly the free
+    (uncontracted) input legs gathered in ``out_ig`` order; an output-unrolled
+    leg is additionally restricted to its per-key slice.
+
+    Single-key (no output-unrolled leg): the output struct is the full gathered
+    legs, built metadata-only via :func:`_zeros_meta` (no data buffer).
+
+    Multi-key (output-unrolled): build a zero skeleton per *surviving* output
+    key and assemble them with the *same* ``block`` + ``drop_leg_history`` the
+    forward pass uses, so ``full_struct`` matches the assembled ``out_data``
+    exactly — including when an output slice has no surviving combo (absent from
+    both). Abelian charge conservation gives the output charge as the fused
+    input charge.
+
+    Skeletons are in canonical form (identity pending-transpose). ``ncon`` may
+    return a value-identical result carrying a *lazy* transpose, so a worker
+    partial's native ``struct``/``trans`` can differ while ``get_legs`` and the
+    value agree — a representation choice, not a correctness difference; yastn
+    arithmetic aligns them when the worker zero-fills to this struct. (No
+    per-operand conjugation is assumed, which the dispatcher does not pass.)"""
+    from ..initialize import zeros as yastn_zeros
+    from ._legs import Leg
+    sym = config.sym
+    out_ig_list = list(out_ig)
+
+    # Each output label is a free leg carried by exactly one (tensor, axis).
+    label_src = {}
+    for k, ig in enumerate(ig_list):
+        for a, lbl in enumerate(ig):
+            if lbl in out_ig_list:
+                label_src[lbl] = (k, a)
+    out_legs_full = [tensors[k].get_legs(a) for k, a in (label_src[L] for L in out_ig_list)]
+
+    n_out = sym.add_charges(*(t.struct.n for t in tensors))
+
+    unroll_labels = list(unroll.keys())
+    sizes = [len(unroll[u]) for u in unroll_labels]
+    label_pos = {u: i for i, u in enumerate(unroll_labels)}
+    output_unroll_axes = {out_ig_list.index(u): u for u in unroll_labels if u in out_ig_list}
+    blocked_axes = sorted(output_unroll_axes.keys())
+    ndim_out = len(out_ig_list)
+    common_legs_axes = ([ax for ax in range(ndim_out) if ax not in blocked_axes]
+                        if blocked_axes else None)
+
+    if common_legs_axes is None:
+        # Single-key: metadata-only, no full zero buffer (the large-output case).
+        d = _zeros_meta(config, out_legs_full, n_out)
+        return {(): d}, d, None
+
+    def _unravel(n):
+        # combo index -> per-unroll-label slice index, in itertools.product order
+        # (last label varies fastest); avoids materializing the full product.
+        idx = [0] * len(sizes)
+        for i in range(len(sizes) - 1, -1, -1):
+            idx[i] = n % sizes[i]
+            n //= sizes[i]
+        return idx
+
+    # Multi-key: a zero skeleton per surviving output key, assembled via the
+    # SAME block()+drop_leg_history the forward pass uses so full_struct matches
+    # out_data exactly.
+    per_key_tensors = {}
+    for n in surviving:
+        idx = _unravel(n)
+        opk = tuple(idx[label_pos[output_unroll_axes[ax]]] for ax in blocked_axes)
+        if opk in per_key_tensors:
+            continue
+        legs = list(out_legs_full)
+        for i, ax in enumerate(blocked_axes):
+            sl = unroll[output_unroll_axes[ax]][opk[i]]
+            legs[ax] = Leg(sym=config, s=out_legs_full[ax].s, t=sl.t, D=sl.D)
+        per_key_tensors[opk] = yastn_zeros(config=config, legs=legs, n=n_out)
+
+    per_key_struct = {opk: _meta_only(t.to_dict(level=1)) for opk, t in per_key_tensors.items()}
+    from ..initialize import block as yastn_block
+    assembled = yastn_block(per_key_tensors, common_legs=common_legs_axes).drop_leg_history()
+    full_struct = _meta_only(assembled.to_dict(level=1))
+    return per_key_struct, full_struct, common_legs_axes
 
 
 def _per_device_input_replicas(input_data_tensors, worker_devs, original_device):
@@ -148,9 +250,11 @@ def _zero_fill_to_full(partial, full_struct_dict, cfg):
     Used by workers to align per-key partial sums to the cached per-key struct.
     """
     from . import Tensor
-    full_size = (full_struct_dict['struct']['size']
-                 if isinstance(full_struct_dict['struct'], dict)
-                 else full_struct_dict['struct'].size)
+    # Leg-first: to_dict(level=1) serializes the struct as {'legs','n','isdiag'}
+    # (no 'size' — it is derived on demand via get_blocks) and emits the total
+    # data size at the top level as full_struct_dict['size'] (== a.size). The
+    # old struct['size']/struct.size lookups both went stale under leg-first.
+    full_size = full_struct_dict['size']
     zeros_data = torch.zeros(full_size,
                              dtype=partial._data.dtype,
                              device=partial._data.device)
@@ -159,10 +263,29 @@ def _zero_fill_to_full(partial, full_struct_dict, cfg):
     return zero_tensor + partial
 
 
+def _install_parent_death_signal():
+    """Linux: ask the kernel to SIGTERM this worker if the parent dies, so a
+    parent killed by signal (no atexit -> _shutdown_all_pools never runs) does
+    not leak non-daemon workers holding CUDA contexts. Best-effort / no-op
+    elsewhere."""
+    try:
+        import os, signal, ctypes
+        PR_SET_PDEATHSIG = 1
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM)
+        # Race: if the parent already died before prctl, we were reparented and
+        # will never get the signal — exit now.
+        if os.getppid() == 1:
+            os._exit(1)
+    except Exception:
+        pass
+
+
 def _worker_main(rank, gpu_dev, config_desc, cmd_q, res_q,
                  log_queue=None, log_level=logging.INFO, logger_levels=None):
     """Worker process entry point. Loops on cmd_q until 'shutdown'."""
     import torch
+    _install_parent_death_signal()
     # Route this worker's logging (notably get_contraction_path path-info
     # reports at INFO level) through the parent's QueueListener. Spawn-mode
     # children inherit no logging config, so without this every log.info call
@@ -217,19 +340,13 @@ def _worker_main(rank, gpu_dev, config_desc, cmd_q, res_q,
                             **ncon_kwargs,
                         )
 
-                    if per_key_struct is None:
-                        # Raw mode (cache miss): no zero-fill — different
-                        # workers may produce partials with different charge
-                        # sectors. Parent handles via yastn '+'.
-                        out = {k: _serialize_yastn(v) for k, v in partials.items()}
-                    else:
-                        # Zero-fill mode (cache hit): all workers' per-key
-                        # tensors share identical shape so parent can sum
-                        # raw data tensors without yastn '+'.
-                        out = {}
-                        for k, p in partials.items():
-                            full_p = _zero_fill_to_full(p, per_key_struct[k], cfg)
-                            out[k] = _serialize_yastn(full_p)
+                    # Zero-fill each partial to its per-key output struct so all
+                    # workers' per-key tensors share identical shape and the
+                    # parent sums raw data tensors directly (no yastn '+').
+                    out = {}
+                    for k, p in partials.items():
+                        full_p = _zero_fill_to_full(p, per_key_struct[k], cfg)
+                        out[k] = _serialize_yastn(full_p)
                     res_q.put(('forward_done', rank, txn_id, out))
                 else:  # backward
                     partials = _contract_with_sliced_unroll(
@@ -301,7 +418,38 @@ class _PersistentWorkerPool:
                 self.worker_devs.append(dev)
                 rank += 1
         self.n_workers = rank
-        self._struct_cache = {}
+        self._struct_cache = OrderedDict()
+
+    def cache_get(self, key):
+        """LRU read of the assembly-recipe cache."""
+        try:
+            self._struct_cache.move_to_end(key)
+            return self._struct_cache[key]
+        except KeyError:
+            return None
+
+    def cache_put(self, key, value):
+        """LRU write; evict the oldest entry past the size bound."""
+        self._struct_cache[key] = value
+        self._struct_cache.move_to_end(key)
+        while len(self._struct_cache) > _STRUCT_CACHE_MAXSIZE:
+            self._struct_cache.popitem(last=False)
+
+    def get_result(self, active_worker_idxs):
+        """Blocking get from ``res_q`` with a liveness guard: if no message
+        arrives within ``_WORKER_POLL_SECONDS`` and an assigned worker has died
+        (CUDA OOM kill, segfault) without posting, raise instead of hanging
+        forever. Legitimately long contractions just keep waiting."""
+        while True:
+            try:
+                return self.res_q.get(timeout=_WORKER_POLL_SECONDS)
+            except _queue.Empty:
+                dead = [(i, self.procs[i].exitcode) for i in active_worker_idxs
+                        if not self.procs[i].is_alive()]
+                if dead:
+                    raise RuntimeError(
+                        f"MP worker(s) died before posting results "
+                        f"(rank, exitcode): {dead} — likely CUDA OOM kill or segfault")
 
     def allocate_txn(self):
         self._next_txn += 1
@@ -342,9 +490,11 @@ def _shutdown_all_pools():
 class _MultiprocSlicedUnrollFunction(torch.autograd.Function):
     """Custom autograd.Function dispatching unrolled combos to a worker pool.
 
-    Inputs: (*input_data_tensors, meta_bundle).
-    Forward: workers compute per-key partials (no_grad); parent merges per key,
-    optionally calls yastn_block, returns assembled out_data.
+    Inputs: (*input_data_tensors, meta_bundle). The per-key output structs are
+    derived from input legs upfront (see _derive_output_structs), so:
+    Forward: workers compute per-key partials (no_grad) and zero-fill each to its
+    per-key struct; parent sums raw data per key, optionally calls yastn_block,
+    returns assembled out_data.
     Backward: parent re-runs yastn_block on saved merged data with autograd
     enabled, extracts per-key grads via local backward, ships per-key grads to
     workers; workers re-run their combos with autograd, call per-key partial
@@ -398,9 +548,10 @@ class _MultiprocSlicedUnrollFunction(torch.autograd.Function):
             ))
 
         n_active = sum(1 for a in worker_assignments if a)
+        active_idxs = [i for i, a in enumerate(worker_assignments) if a]
         per_worker_partials = []  # list of {key: serialized yastn dict}
         while len(per_worker_partials) < n_active:
-            msg = pool.res_q.get()
+            msg = pool.get_result(active_idxs)
             kind, _rank, _txn, payload = msg
             if _txn != txn_id:
                 # leftover from an earlier transaction that raised mid-drain
@@ -410,78 +561,35 @@ class _MultiprocSlicedUnrollFunction(torch.autograd.Function):
                 raise RuntimeError(f"worker forward failed: {msg}")
             per_worker_partials.append(payload)
 
-        if per_key_struct is None:
-            # Cache-miss path: workers returned RAW partials. Merge via yastn '+'
-            # which handles charge-sector union across workers, then derive
-            # struct from the merged result and populate the cache so future
-            # calls hit the zero-fill fast path.
-            from . import Tensor
-            merged_yastn = {}
-            for w_partials in per_worker_partials:
-                for key, ydict in w_partials.items():
-                    t = Tensor.from_dict(ydict, config=parent_config)
-                    if key in merged_yastn:
-                        merged_yastn[key] = merged_yastn[key] + t
-                    else:
-                        merged_yastn[key] = t
-            if not merged_yastn:
-                from . import YastnError
-                raise YastnError("No valid charge sectors found for contraction.")
-
-            common_legs_axes, _ndim = _compute_common_legs_axes(merged_yastn, unroll, out_ig)
-            if common_legs_axes is None:
-                assembled = merged_yastn[()]
-            else:
-                from ..initialize import block as yastn_block
-                assembled = yastn_block(merged_yastn, common_legs=common_legs_axes)
-                assembled = assembled.drop_leg_history()
-
-            per_key_struct = {k: _meta_only(v.to_dict(level=1))
-                              for k, v in merged_yastn.items()}
-            full_struct = _meta_only(assembled.to_dict(level=1))
-            pool._struct_cache[meta['cache_key']] = (per_key_struct, full_struct,
-                                                     common_legs_axes,
-                                                     meta['surviving'],
-                                                     meta['pf_trim_per_combo'],
-                                                     meta['dim_overrides_per_combo'])
-            # Update meta in place so backward (and the wrap step in
-            # _contract_with_sliced_unroll_mp) see the populated struct.
-            meta['per_key_struct'] = per_key_struct
-            meta['common_legs_axes'] = common_legs_axes
-            meta['full_struct'] = full_struct
-
-            merged_keys = sorted(merged_yastn.keys())
-            merged_data = {k: merged_yastn[k]._data for k in merged_keys}
-            out_data = assembled._data
+        # Workers zero-filled each partial to its per-key output struct, so all
+        # per-key tensors share shape and we sum raw torch data tensors directly
+        # (gathering each worker's contribution back to the original device).
+        merged_data = {}
+        for w_partials in per_worker_partials:
+            for key, ydict in w_partials.items():
+                d = ydict['data']
+                if str(d.device) != str(original_device):
+                    d = d.to(original_device)
+                if key in merged_data:
+                    merged_data[key] = merged_data[key] + d
+                else:
+                    merged_data[key] = d
+        if not merged_data:
+            from . import YastnError
+            raise YastnError("No valid charge sectors found for contraction.")
+        merged_keys = sorted(merged_data.keys())
+        if common_legs_axes is None:
+            out_data = merged_data[()]
         else:
-            # Cache-hit path: workers zero-filled, all per-key tensors share
-            # shape so we can sum raw torch data tensors directly.
-            merged_data = {}
-            for w_partials in per_worker_partials:
-                for key, ydict in w_partials.items():
-                    d = ydict['data']
-                    if str(d.device) != str(original_device):
-                        d = d.to(original_device)
-                    if key in merged_data:
-                        merged_data[key] = merged_data[key] + d
-                    else:
-                        merged_data[key] = d
-            if not merged_data:
-                from . import YastnError
-                raise YastnError("No valid charge sectors found for contraction.")
-            merged_keys = sorted(merged_data.keys())
-            if common_legs_axes is None:
-                out_data = merged_data[()]
-            else:
-                from . import Tensor
-                from ..initialize import block as yastn_block
-                per_key_tensors = {}
-                for k in merged_keys:
-                    tdict = {**per_key_struct[k], 'data': merged_data[k]}
-                    per_key_tensors[k] = Tensor.from_dict(tdict, config=parent_config)
-                assembled = yastn_block(per_key_tensors, common_legs=common_legs_axes)
-                assembled = assembled.drop_leg_history()
-                out_data = assembled._data
+            from . import Tensor
+            from ..initialize import block as yastn_block
+            per_key_tensors = {}
+            for k in merged_keys:
+                tdict = {**per_key_struct[k], 'data': merged_data[k]}
+                per_key_tensors[k] = Tensor.from_dict(tdict, config=parent_config)
+            assembled = yastn_block(per_key_tensors, common_legs=common_legs_axes)
+            assembled = assembled.drop_leg_history()
+            out_data = assembled._data
 
         ctx.save_for_backward(*input_data_tensors,
                               *(merged_data[k] for k in merged_keys))
@@ -562,9 +670,10 @@ class _MultiprocSlicedUnrollFunction(torch.autograd.Function):
             ))
 
         n_active = sum(1 for a in worker_assignments if a)
+        active_idxs = [i for i, a in enumerate(worker_assignments) if a]
         per_worker_input_grads = []
         while len(per_worker_input_grads) < n_active:
-            msg = pool.res_q.get()
+            msg = pool.get_result(active_idxs)
             kind, _rank, _txn, payload = msg
             if _txn != txn_id:
                 # leftover from an earlier transaction that raised mid-drain
@@ -618,22 +727,25 @@ def _contract_with_sliced_unroll_mp(*args, unroll, optimize, checkpoint_loop=Fal
     per_combo_path = bool(kwargs.get("per_combo_path", False))
     # Cache: (per_key_struct, full_struct, common_legs_axes, surviving_combos,
     #         pf_trim_per_combo, dim_overrides_per_combo)
-    cache_key = _build_cache_key([t.to_dict(level=1) for t in tensors],
+    cache_key = _build_cache_key(tensors,
                                  unroll, ig_list, out_ig, optimize, swap, per_combo_path)
-    cached = pool._struct_cache.get(cache_key)
+    cached = pool.cache_get(cache_key)
     if cached is not None:
         # Cache holds prefilter results too, so workers always get the
         # precomputed payload without re-running _metadata_filter_combos.
         (per_key_struct, full_struct, common_legs_axes,
          surviving, pf_trim_per_combo, dim_overrides_per_combo) = cached
     else:
-        per_key_struct = None
-        full_struct = None
-        common_legs_axes = None
         from .oe_blocksparse import _metadata_filter_combos
         surviving, pf_trim_per_combo, dim_overrides_per_combo = _metadata_filter_combos(
             tensors, ig_list, out_ig, unroll, optimize, swap,
             collect_dim_overrides=per_combo_path)
+        # Derive the assembly structs from input legs (no data contraction);
+        # workers always zero-fill and the cache is a pure performance memo.
+        per_key_struct, full_struct, common_legs_axes = _derive_output_structs(
+            tensors, ig_list, out_ig, unroll, surviving, parent_config)
+        pool.cache_put(cache_key, (per_key_struct, full_struct, common_legs_axes,
+                                   surviving, pf_trim_per_combo, dim_overrides_per_combo))
 
     # Distribute SURVIVING combo indices round-robin across workers
     worker_assignments = [[] for _ in range(pool.n_workers)]
@@ -662,15 +774,13 @@ def _contract_with_sliced_unroll_mp(*args, unroll, optimize, checkpoint_loop=Fal
         'full_struct': full_struct,
         'parent_config': parent_config,
         'original_device': original_device,
-        'cache_key': cache_key,
-        'surviving': surviving,
         'checkpoint_loop': checkpoint_loop,
         'pf_trim_per_combo': pf_trim_per_combo,
         'dim_overrides_per_combo': dim_overrides_per_combo,
     }
 
     out_data = _MultiprocSlicedUnrollFunction.apply(*input_data_tensors, meta)
-    # Function.forward populates meta['full_struct'] on cache miss.
+    # full_struct is derived from input legs in the dispatcher (above).
     full_struct = meta['full_struct']
     from . import Tensor
     return Tensor.from_dict({**full_struct, 'data': out_data}, config=parent_config)

--- a/yastn/tensor/linalg.py
+++ b/yastn/tensor/linalg.py
@@ -387,7 +387,7 @@ def _meta_svd(sym, struct, sU, nU, k_block):
         ('slS', np.int64, (2,)),
         ('slV', np.int64, (2,)),
         ('DV',  np.int64, (2,))])
-    meta = np.hstack([bl_a.slc[ind_a], bl_a.D[ind_a], bl_U.slc[inds], bl_U.D[inds], bl_S.slc, bl_V.slc, bl_V.D], dtype=np.int64)
+    meta = np.hstack([bl_a.slc[ind_a], bl_a.D[ind_a], bl_U.slc[inds], bl_U.D[inds], bl_S.slc, bl_V.slc, bl_V.D]).astype(np.int64, copy=False)
     meta = meta.view(meta_dt).reshape(-1)
     sizes = (bl_U.size, bl_S.size, bl_V.size)
     return meta, sizes, bl_U.struct, bl_S.struct, bl_V.struct
@@ -792,7 +792,7 @@ def _meta_qr(sym, struct, sQ):
         ('DQ',  np.int64, (2,)),
         ('slR', np.int64, (2,)),
         ('DR',  np.int64, (2,))])
-    meta = np.hstack([bl_a.slc[inds], bl_a.D[inds], bl_Q.slc[inds], bl_Q.D[inds], bl_R.slc, bl_R.D], dtype=np.int64)
+    meta = np.hstack([bl_a.slc[inds], bl_a.D[inds], bl_Q.slc[inds], bl_Q.D[inds], bl_R.slc, bl_R.D]).astype(np.int64, copy=False)
     meta = meta.view(meta_dt).reshape(-1)
     sizes = (bl_Q.size, bl_R.size)
     return meta, sizes, bl_Q.struct, bl_R.struct

--- a/yastn/tensor/linalg.py
+++ b/yastn/tensor/linalg.py
@@ -279,7 +279,8 @@ def svd(a, axes=(0, 1), sU=1, nU=True, compute_uv=True,
         logger.info(f"{fname} D_block {kwargs.get('D_block', 'NA')}")
         logger.info(f"{fname} k_block {k_block}")
 
-    meta, sizes, struct_Um, struct_S, struct_Vm = _meta_svd(sym, struct_am, sU, nU, k_block)
+    nonzero = _nonzero_sectors(a.config.backend, data, sym, struct_am)
+    meta, sizes, struct_Um, struct_S, struct_Vm = _meta_svd(sym, struct_am, sU, nU, k_block, nonzero=nonzero)
     ls_s = _LegSlices_trivial(struct_S.legs[0])
 
     if compute_uv and policy == 'fullrank':
@@ -336,7 +337,22 @@ def svd(a, axes=(0, 1), sU=1, nU=True, compute_uv=True,
     return U, S, V
 
 
-def _meta_svd(sym, struct, sU, nU, k_block):
+def _nonzero_sectors(backend, data, sym, struct):
+    """
+    Per-block flags of a merged matrix: True if the block has any nonzero element,
+    aligned with the block order of ``get_blocks(sym, struct)``.
+
+    Returns None when all blocks are nonzero and there is nothing to filter.
+    For an all-zero matrix every sector is dropped, giving empty U, S, V.
+    """
+    bl = get_blocks(sym, struct)
+    flags = backend.nonzero_blocks(data, bl.slc)
+    if all(flags):
+        return None
+    return flags
+
+
+def _meta_svd(sym, struct, sU, nU, k_block, nonzero=None):
     """
     meta and struct for svd
     U has signature = (legs[0].s, sU)
@@ -352,6 +368,12 @@ def _meta_svd(sym, struct, sU, nU, k_block):
 
     ax0 = 1 if nU else 0
     minD = {tuple(tt): min(DD) for tt, DD in zip(bl_a.t[:, ax0, :].tolist(), bl_a.D)}
+    if nonzero is not None:
+        # exclude exactly-zero blocks from the decomposition;
+        # their sectors reappear as zero blocks in any product with U, S, V.
+        for tt, nz in zip(bl_a.t[:, ax0, :].tolist(), nonzero):
+            if not nz:
+                minD[tuple(tt)] = 0
     if k_block is not None:
         if isinstance(k_block, dict):
             sector_minD = min(k_block.values())  # TODO: control default for sectors not present in k_block
@@ -879,7 +901,12 @@ def eigh(a, axes, sU=1, Uaxis=-1, which='LR', policy='fullrank', **kwargs) -> tu
     if ls_l != ls_r:
         raise YastnError("Tensor likely is not hermitian. Legs of effective square blocks do not match.")
 
-    meta, sizes, struct_Um, struct_S = _meta_eigh(sym, struct_am, sU, k_block)
+    # filter zero blocks only for the partial-spectrum solver; 'fullrank' keeps
+    # them so that U remains a complete eigenbasis (with eigenvalue-0 sectors).
+    nonzero = None
+    if policy == 'block_lanczos':
+        nonzero = _nonzero_sectors(a.config.backend, data, sym, struct_am)
+    meta, sizes, struct_Um, struct_S = _meta_eigh(sym, struct_am, sU, k_block, nonzero=nonzero)
     ls = _LegSlices_trivial(struct_Um.legs[1])
 
     if policy == 'fullrank':
@@ -920,7 +947,7 @@ def eigh(a, axes, sU=1, Uaxis=-1, which='LR', policy='fullrank', **kwargs) -> tu
     return S, U
 
 
-def _meta_eigh(sym, struct, sU, k_block):
+def _meta_eigh(sym, struct, sU, k_block, nonzero=None):
     """
     meta and struct for eigh
     U has signature = (legs[0].s, sU)
@@ -930,6 +957,12 @@ def _meta_eigh(sym, struct, sU, k_block):
 
     n0 = sym.zero()
     minD = {tuple(tt): min(DD) for tt, DD in zip(bl_a.t[:, 1, :].tolist(), bl_a.D)}
+    if nonzero is not None:
+        # exclude exactly-zero blocks; their eigenpairs (all with eigenvalue 0)
+        # are dropped, consistent with a partial-spectrum solve.
+        for tt, nz in zip(bl_a.t[:, 1, :].tolist(), nonzero):
+            if not nz:
+                minD[tuple(tt)] = 0
     if k_block is not None:
         if isinstance(k_block, dict):
             sector_minD = min(k_block.values())  # TODO: control default for sectors not present in k_block

--- a/yastn/tn/fpeps/envs/_env_ctm_dist_mp_AD.py
+++ b/yastn/tn/fpeps/envs/_env_ctm_dist_mp_AD.py
@@ -84,7 +84,7 @@ class _DistCTMPool:
     def __init__(self, devices, config_desc):
         import sys
         import torch.multiprocessing as _mp
-        from yastn.yastn._mp_logging import (
+        from ...._mp_logging import (
             start_parent_log_listener, parent_log_level, snapshot_logger_levels)
 
         mctx = _mp.get_context('spawn')
@@ -201,7 +201,7 @@ class _DistCTMPool:
                 p.terminate()
         # Stop the listener only after workers are joined, so any record they
         # emitted has been enqueued before the listener drains and stops.
-        from yastn.yastn._mp_logging import stop_parent_log_listener
+        from ...._mp_logging import stop_parent_log_listener
         stop_parent_log_listener(self.log_listener)
 
 
@@ -361,9 +361,9 @@ def _serialize_args(args):
         ('Tensor', meta) -- consumes 1 data tensor
         ('DPT', extra, bra_meta, ket_meta) -- consumes 2 (bra, ket)
     """
-    from yastn.yastn.tensor import Tensor
-    from yastn.yastn.tn.fpeps._doublePepsTensor import DoublePepsTensor
-    from yastn.yastn.tn.fpeps import Site
+    from ....tensor import Tensor
+    from .._doublePepsTensor import DoublePepsTensor
+    from .. import Site
 
     skeleton = []
     flat_data = []
@@ -389,8 +389,8 @@ def _serialize_args(args):
 
 def _deserialize_args(skeleton, flat_data, cfg):
     """Rebuild args from skeleton + flat data tensors (on worker side)."""
-    from yastn.yastn.tensor import Tensor
-    from yastn.yastn.tn.fpeps._doublePepsTensor import DoublePepsTensor
+    from ....tensor import Tensor
+    from .._doublePepsTensor import DoublePepsTensor
 
     args = []
     di = 0
@@ -498,7 +498,7 @@ def _worker_main(rank, device, config_desc, cmd_q, res_q, parent_sys_path,
     # Route this worker's logging through the parent's QueueListener. Spawn-mode
     # children inherit no logging config, so without this every log.info call
     # in a worker is silently dropped.
-    from yastn.yastn._mp_logging import install_worker_log_handler
+    from ...._mp_logging import install_worker_log_handler
     install_worker_log_handler(log_queue, log_level,
                                tag=f"dist_ctm_AD rank {rank} dev {device}",
                                logger_levels=logger_levels)
@@ -507,7 +507,7 @@ def _worker_main(rank, device, config_desc, cmd_q, res_q, parent_sys_path,
         gpu_idx = int(str(device).split(':')[1])
         torch.cuda.set_device(gpu_idx)
 
-    from yastn.yastn.tensor._initialize import make_config
+    from ....tensor._initialize import make_config
     cfg = make_config(**{**config_desc, 'default_device': str(device)})
 
     log.info("worker ready")
@@ -580,10 +580,10 @@ def _stage12_compute(args, extra):
     -- one per stage, both alive in worker memory -- and the IPC
     round-trip that shipped halves between the stages.
     """
-    from yastn.yastn.tn.fpeps.envs._env_contractions import (
+    from ._env_contractions import (
         halves_4x4_lhr, halves_4x4_tvb,
     )
-    from yastn.yastn.tn.fpeps.envs._env_ctm_dist_mp import (
+    from ._env_ctm_dist_mp import (
         projectors_move_rh, projectors_move_lh,
         projectors_move_tv, projectors_move_bv,
     )
@@ -615,7 +615,7 @@ def _stage3_compute(args, extra):
     Returns whatever update_env_dir returns (a tuple of yastn Tensors,
     possibly with None entries for boundary cases).
     """
-    from yastn.yastn.tn.fpeps.envs._env_contractions import update_env_dir
+    from ._env_contractions import update_env_dir
     return update_env_dir(extra['move'], *args)
 
 
@@ -738,8 +738,8 @@ def _stage_bwd_via_saved(args, saved_graphs, device):
 # ===========================================================================
 
 def _find_ref_config(args):
-    from yastn.yastn.tensor import Tensor
-    from yastn.yastn.tn.fpeps._doublePepsTensor import DoublePepsTensor
+    from ....tensor import Tensor
+    from .._doublePepsTensor import DoublePepsTensor
     for a in args:
         if isinstance(a, Tensor):
             return a.config
@@ -841,7 +841,7 @@ def _stage_apply_batched(pool, stage, jobs):
     main skips the ``_BatchedFn.apply`` wrap entirely.
     """
     import torch
-    from yastn.yastn.tensor import Tensor
+    from ....tensor import Tensor
 
     autograd_enabled = torch.is_grad_enabled()
 
@@ -956,7 +956,7 @@ def update_core_AD_(env, move, opts_svd, devices, **kwargs):
     have ``_data`` carrying autograd tracking, so backward through
     ``env``'s output env tensors flows to the original input tensors.
     """
-    from yastn.yastn.tn.fpeps.envs._env_contractions import (
+    from ._env_contractions import (
         update_env_fetch_args,
     )
 
@@ -1115,7 +1115,7 @@ def iterate_AD_(env, opts_svd, moves='hv', method='2x2', max_sweeps=1,
     cleanup so workers don't accumulate activations across sweeps.
     """
     import torch
-    from yastn.yastn.tn.fpeps.envs._env_ctm import CTMRG_out
+    from ._env_ctm import CTMRG_out
 
     if devices is None or len(devices) < 1:
         raise ValueError("iterate_AD_ requires devices=...")

--- a/yastn/tn/fpeps/envs/fixed_pt.py
+++ b/yastn/tn/fpeps/envs/fixed_pt.py
@@ -442,7 +442,16 @@ def fast_env_T_gauge_multi_sites(config, T_olds, T_news):
     def normalize_QR(Q, R):
         # make the diagonal entries of R matrix positive
         R_sign = R.diag()
-        R_sign._data = R_sign._data.conj()/abs(R_sign._data)
+        d = R_sign._data
+        absd = abs(d)
+        # Exact zeros can sit on R's diagonal: leg-first materializes every
+        # symmetry-allowed block and qr keeps the zero ones (svd/eigh drop them via
+        # `nonzero`; _meta_qr has no such filter). A zero has no defined phase -- use
+        # 1, not 0, so R_sign stays unitary and Q @ R_sign.H remains an isometry.
+        # clamp_min keeps the discarded branch of `where` free of 0/0 = NaN.
+        tiny = torch.finfo(absd.dtype).tiny
+        phase = torch.where(absd > 0, d.conj() / absd.clamp_min(tiny), torch.ones_like(d))
+        R_sign._data = phase
         return Q@R_sign.H, R_sign@R
 
 

--- a/yastn/tn/fpeps/envs/fixed_pt.py
+++ b/yastn/tn/fpeps/envs/fixed_pt.py
@@ -790,17 +790,19 @@ class FixedPoint(torch.autograd.Function):
             Sequence[Tensor]: raw environment data for the backward pass.
         """
 
-        # Pin main-process current CUDA device to where env tensors live.
-        # MP workers each set their own current device; the main process
-        # also runs CUDA ops here (gauge-fixing fp CTM step, etc.), and
-        # tapp_torch (torch_cpp backend) launches kernels on the current
-        # device — mismatch causes "illegal memory access" when devices[0]
-        # is not cuda:0.
-        if devices:
-            _dev0 = devices[0]
-            if isinstance(_dev0, str) and _dev0.startswith("cuda"):
-                import torch
-                torch.cuda.set_device(_dev0)
+        # Pin main-process current CUDA device to where the ENV TENSORS live
+        # (env.config.default_device), NOT devices[0]. The MP workers each set
+        # their own current device; the main process also runs CUDA ops here
+        # (gauge-fixing fp CTM step, etc.), and tapp_torch (torch_cpp backend)
+        # launches kernels on the current device -- a mismatch causes "illegal
+        # memory access". When the main/home device is decoupled from the CTM
+        # worker pool (e.g. env on cuda:0, workers on cuda:1-3), devices[0] is
+        # NOT the env device, so we must pin to the env's own device. When they
+        # coincide (default) this is identical to the old devices[0] pin.
+        _env_dev = getattr(env.config, "default_device", None)
+        if isinstance(_env_dev, str) and _env_dev.startswith("cuda"):
+            import torch
+            torch.cuda.set_device(_env_dev)
 
         # 1. Converge the environment using CTMRG
         ctm_env_out, converged, *FixedPoint.ctm_log, FixedPoint.t_ctm, FixedPoint.t_check = FixedPoint.get_converged_env(
@@ -836,9 +838,13 @@ class FixedPoint(torch.autograd.Function):
 
         # 3. Find the gauge transformation
         t0 = time.perf_counter()
-        env_gauge, phase_dict = find_gauge_multi_sites(env_converged, ctm_env_out, verbose=True)
-        if env_gauge is None:
+        # find_gauge_multi_sites returns a bare None (not a 2-tuple) when no gauge is
+        # found, so the None check has to happen BEFORE the unpack -- otherwise it is
+        # the unpack that fails, with a TypeError that hides the real diagnostic.
+        _gauge = find_gauge_multi_sites(env_converged, ctm_env_out, verbose=True)
+        if _gauge is None:
             raise NoFixedPointError(code=1, message="No fixed point found: fail to find the gauge matrix!")
+        env_gauge, phase_dict = _gauge
         t1 = time.perf_counter()
         log.info(f"{type(ctx).__name__}.forward FP gauge-fixing t {t1-t0} [s]")
 

--- a/yastn/tn/mps/_mps_obc.py
+++ b/yastn/tn/mps/_mps_obc.py
@@ -194,16 +194,16 @@ class MpoPBC(_MpsMpoParent):
                0     2        2N-2
 
         """
-        ten = self.factor * self.A[self.first]
+        ten = self.A[self.first]
         if self.N == 1:
-            return ten.trace(axes=(0, 2))
+            return self.factor * ten.trace(axes=(0, 2))
         for n in self.sweep(to='last', df=1):
             ind = n + 1 if self.nr_phys == 1 else 2 * n
             if n == self.last:
                 ten = tensordot(ten, self.A[n], axes=((ind, 0), (0, 2)))
             else:
                 ten = tensordot(ten, self.A[n], axes=(ind, 0))
-        return ten
+        return self.factor * ten
 
 
 class MpsMpoOBC(_MpsMpoParent):


### PR DESCRIPTION
Ports the multi-GPU CTM / OE-contraction work onto the leg-first data model and
fixes what the merge broke along the way.

**MP-pool struct-cache key.** Collapsed to the total charge `n` under leg-first
and collided distinct structures in the shared pool cache. Now keyed on a cheap
lossless struct identity (`struct`/`trans`/`hfs`/`mfs`), which also drops the
per-call serialization.

**SVD/eigh zero-block filter.** Exactly-zero blocks are dropped rather than fed to
the backend.

**Derive MP-pool output structs from legs.** Under leg-first the output structs of
a sliced contraction are determined by the input legs alone, so no data pass is
needed to discover them.

**Environment.** py3.10 syntax, numpy<2 compat, package imports.
