### PR TITLE
fixed_pt: order raw_peps_params by site2index to match backward grad order

### DIFF
--- a/yastn/tn/fpeps/envs/fixed_pt.py
+++ b/yastn/tn/fpeps/envs/fixed_pt.py
@@ -626,7 +626,8 @@ def fp_ctmrg(env: EnvCTM, \
         EnvCTM: Environment at fixed point.
         Sequence[Tensor]: raw environment data for the backward pass.
     """
-    raw_peps_params= tuple( env.psi.ket[s]._data for s in env.psi.ket.sites() )
+    ket = env.psi.ket
+    raw_peps_params= tuple( ket[s]._data for s in sorted(ket.sites(), key=ket.site2index) )
     env, env_t_meta, env_slices, env_1d = FixedPoint.apply(env, ctm_opts_fwd, ctm_opts_fp, fwd_devices, *raw_peps_params)
     env_t_dict = _assemble_dict_from_1d(env_t_meta, env_1d, env_slices)
     env.env = Lattice.from_dict(env_t_dict)

--- a/yastn/tn/fpeps/envs/fixed_pt_c4v.py
+++ b/yastn/tn/fpeps/envs/fixed_pt_c4v.py
@@ -115,7 +115,11 @@ def fp_ctmrg_c4v(env: EnvCTM_c4v, \
         EnvCTM_c4v: Environment at fixed point.
         Sequence[Tensor]: raw environment data for the backward pass.
     """
-    raw_peps_params= tuple( env.psi.ket[s]._data for s in env.psi.ket.sites() )
+    # Order leaves by site2index to match the backward's dA order (see the detailed
+    # note in fixed_pt.py:fp_ctmrg). C4v is single-unique-site so this is an identity
+    # here, but it keeps the apply-input / returned-gradient layout invariant explicit.
+    ket = env.psi.ket
+    raw_peps_params= tuple( ket[s]._data for s in sorted(ket.sites(), key=ket.site2index) )
     env_converged, env_t_meta, env_slices, env_1d = FixedPoint_c4v.apply(env, ctm_opts_fwd, ctm_opts_fp, *raw_peps_params)
     env_t_dict = _assemble_dict_from_1d(env_t_meta, env_1d, env_slices)
     env_converged.env = Lattice.from_dict(env_t_dict)


### PR DESCRIPTION
Potential bug in fixed_pt.py: the raw data is assembled in coordinate order, whereas split_data_and_meta(env_dict['psi']) uses label order (via site2index). The program raises an error whenever the two orders disagree. The fix assembles the raw data in label order as well.