### PR TITLE
Lazy leg first update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+29-07-2026
+- backend-agnostic GPU builder of the cuTensor tensordot metadata: `_meta_tensordot_cutensor_gpu`
+  no longer calls torch directly. The array backend is loaded from `backend_id` and injected into
+  its helpers, so the GPU meta path can run on any numpy-like backend (torch now; cupy/jax in future).
+- new `yastn.backend.import_backend(backend_id)` returning the backend module for a `BACKEND_ID`
+  ('np', 'torch', 'torch_cutensor'); `make_config` now uses it to resolve string backends.
+- new `make_config` option `meta_tensordot_policy` ('cpu' | 'gpu' | 'auto', default 'auto') selecting
+  the algorithm that builds the block-sparsity metadata for `tensordot`; 'auto' uses the GPU builder
+  when a GPU device is present, otherwise the CPU builder. Can be overridden with the environment
+  variable `YASTN_META_CUTENSOR` = 'GPU' | 'CPU'.
+- new `make_config` option `lazy_threshold` (float) controlling lazy initialization of contraction
+  outputs — only the blocks actually needed are created instead of all symmetry-allowed blocks —
+  based on the fraction of blocks involved; `0` disables lazy evaluation (default for the cuTensor
+  backend), values toward `1` enable it more aggressively, and it defaults to `0.5` on other backends.
+- backends expose low-level, numpy-aligned array primitives used by the GPU meta:
+  `unique`, `searchsorted`, `isin`, `nonzero`, `cumsum`, `concatenate`, `repeat`, `where`,
+  `zeros_like`, `full_like`, `arange`; backend `DTYPE` gains `int32` and `int64`.
+
+
 20-07-2026
 - renaming torch_cpp to torch_cutensor backend
 

--- a/yastn/backend/__init__.py
+++ b/yastn/backend/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2024 The YASTN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+""" Backends and their lookup by ``BACKEND_ID``. """
+from functools import lru_cache
+
+__all__ = ['import_backend']
+
+
+@lru_cache(maxsize=None)
+def import_backend(backend_id):
+    """
+    Load a yastn backend module by its ``BACKEND_ID`` string (``'np'``, ``'torch'``,
+    ``'torch_cutensor'``). Cached so repeated lookups return the same module object.
+    Raises ``ValueError`` for an unknown id.
+    """
+    if backend_id in (None, 'np', 'numpy'):
+        from . import backend_np
+        return backend_np
+    if backend_id == 'torch':
+        from . import backend_torch
+        return backend_torch
+    if backend_id == 'torch_cutensor':
+        from . import backend_torch_cutensor  # pragma: no cover
+        return backend_torch_cutensor  # pragma: no cover
+    raise ValueError("backend encoded as string only supports: 'np', 'torch', 'torch_cutensor'")

--- a/yastn/backend/backend_np.py
+++ b/yastn/backend/backend_np.py
@@ -52,6 +52,11 @@ def get_device(x):
     return 'cpu'
 
 
+def is_cpu_device(device) -> bool:
+    """ NumPy arrays live on the host; unset/cpu device counts as CPU. """
+    return not device or 'cpu' in str(device).lower()
+
+
 def random_seed(seed):
     rng['rng'] = np.random.default_rng(seed)
 

--- a/yastn/backend/backend_np.py
+++ b/yastn/backend/backend_np.py
@@ -27,6 +27,8 @@ DTYPE = {'float32': np.float32,
          'float64': np.float64,
          'complex64': np.complex64,
          'complex128': np.complex128,
+         'int32': np.int32,
+         'int64': np.int64,
          'bool': bool}
 
 
@@ -273,6 +275,57 @@ def absolute(data):
 
 def bitwise_not(data):
     return np.bitwise_not(data)
+
+
+##############################################################
+#   low-level integer/index array primitives (numpy-aligned) #
+#   backend-agnostic building blocks for the GPU meta path   #
+##############################################################
+
+
+def unique(x, return_inverse=False, return_counts=False):
+    return np.unique(x, return_inverse=return_inverse, return_counts=return_counts)
+
+
+def searchsorted(a, v):
+    return np.searchsorted(a, v)
+
+
+def isin(a, b):
+    return np.isin(a, b)
+
+
+def nonzero(x):
+    """ numpy-aligned: tuple of index arrays, one per dimension. """
+    return np.nonzero(x)
+
+
+def cumsum(x, axis=0):
+    return np.cumsum(x, axis=axis)
+
+
+def concatenate(seq, axis=0):
+    return np.concatenate(tuple(seq), axis=axis)
+
+
+def repeat(x, repeats):
+    return np.repeat(x, repeats)
+
+
+def where(condition, x, y):
+    return np.where(condition, x, y)
+
+
+def zeros_like(x):
+    return np.zeros_like(x)
+
+
+def full_like(x, fill_value):
+    return np.full_like(x, fill_value)
+
+
+def arange(*args, device='cpu'):
+    return np.arange(*args)
 
 
 def safe_svd(a):

--- a/yastn/backend/backend_torch.py
+++ b/yastn/backend/backend_torch.py
@@ -32,7 +32,7 @@ from ._backend_torch_backwards import kernel_embed_transpose, kernel_transpose_a
 
 
 __all__= ['DTYPE', 'get_dtype', 'get_yastn_dtype',
-    'nvtx', 'cuda_is_available', 'get_device', 'move_to',
+    'nvtx', 'cuda_is_available', 'get_device', 'is_cpu_device', 'move_to',
     'grad', 'requires_grad_', 'requires_grad', 'detach', 'detach_', 'clone', 'copy', 'checkpoint',
     'random_seed', 'randint',
     'to_numpy', 'get_shape', 'get_size', 'diag_create', 'diag_get', 'real', 'is_complex', 'conj',
@@ -83,6 +83,13 @@ def is_complex(x):
 
 def get_device(x)->str:
     return str(x.device)
+
+
+def is_cpu_device(device) -> bool:
+    """ Whether ``device`` refers to a host (CPU) device. Unset device (None/'') counts as CPU. """
+    if not device:
+        return True
+    return torch.device(device).type == 'cpu'
 
 
 def random_seed(seed):

--- a/yastn/backend/backend_torch.py
+++ b/yastn/backend/backend_torch.py
@@ -48,7 +48,9 @@ __all__= ['DTYPE', 'get_dtype', 'get_yastn_dtype',
     'merge_to_dense', 'merge_super_blocks', 'is_independent',
     'apply_mask', 'embed_mask',
     'embed_transpose', 'transpose_and_merge', 'unmerge',
-    'negate_blocks', 'gather_slices', 'bitwise_not']
+    'negate_blocks', 'gather_slices', 'bitwise_not',
+    'unique', 'searchsorted', 'isin', 'nonzero', 'cumsum', 'concatenate',
+    'repeat', 'where', 'zeros_like', 'full_like', 'arange']
 
 
 torch.random.seed()
@@ -57,6 +59,8 @@ DTYPE = {'float32': torch.float32,
          'float64': torch.float64,
          'complex64': torch.complex64,
          'complex128': torch.complex128,
+         'int32': torch.int32,
+         'int64': torch.int64,
          'bool': torch.bool}
 
 
@@ -77,7 +81,7 @@ def is_complex(x):
     return x.is_complex()
 
 
-def get_device(x):
+def get_device(x)->str:
     return str(x.device)
 
 
@@ -307,6 +311,58 @@ def absolute(data):
 
 def bitwise_not(data):
     return torch.bitwise_not(data)
+
+
+##############################################################
+#   low-level integer/index array primitives (numpy-aligned) #
+#   backend-agnostic building blocks for the GPU meta path   #
+##############################################################
+
+
+def unique(x, return_inverse=False, return_counts=False):
+    return torch.unique(x, return_inverse=return_inverse, return_counts=return_counts)
+
+
+def searchsorted(a, v):
+    return torch.searchsorted(a, v)
+
+
+def isin(a, b):
+    return torch.isin(a, b)
+
+
+def nonzero(x):
+    """ numpy-aligned: tuple of index arrays, one per dimension. """
+    return torch.nonzero(x, as_tuple=True)
+
+
+def cumsum(x, axis=0):
+    return torch.cumsum(x, dim=axis)
+
+
+def concatenate(seq, axis=0):
+    return torch.cat(tuple(seq), dim=axis)
+
+
+def repeat(x, repeats):
+    """ numpy-aligned np.repeat: element-wise repeat (torch.repeat_interleave). """
+    return torch.repeat_interleave(x, repeats)
+
+
+def where(condition, x, y):
+    return torch.where(condition, x, y)
+
+
+def zeros_like(x):
+    return torch.zeros_like(x)
+
+
+def full_like(x, fill_value):
+    return torch.full_like(x, fill_value)
+
+
+def arange(*args, device='cpu'):
+    return torch.arange(*args, device=device)
 
 
 def svd_lowrank(data, meta, sizes, **kwargs):

--- a/yastn/tensor/_auxiliary.py
+++ b/yastn/tensor/_auxiliary.py
@@ -38,8 +38,9 @@ class _config(NamedTuple):
     default_fusion: str = 'hard'
     force_fusion: str = None
     tensordot_policy: str = 'fuse_contracted'
-    lazy_threshold: float = 0.5
-    # 0 does not use lazy;
+    meta_tensordot_policy: str = 'auto'
+    lazy_threshold: float= None
+    # 0 does not use lazy, default for cutensor backend;
     # 1 uses lazy whenever possible;
     # for (0, 1) uses lazy when the fraction of
     # eliminated blocks exceeds lazy_threshold

--- a/yastn/tensor/_auxiliary.py
+++ b/yastn/tensor/_auxiliary.py
@@ -428,6 +428,60 @@ def argsort_t(tset):
     return np.argsort(tset_view)
 
 
+def _encode_rows_shared(tsets):
+    """
+    Order-preserving int64 keys for the rows of each 2-D array in ``tsets`` (all sharing the
+    same number of columns), computed over the shared per-column value set so that equal rows
+    across arrays receive equal keys. Returns a list of 1-D int64 key arrays (one per input),
+    or ``None`` if the mixed-radix key space would overflow int64.
+
+    The encoding is monotonic w.r.t. the per-column lexicographic order used by
+    ``np.unique(..., axis=0)`` and by a ``[('', dt)] * ncols`` structured-dtype view (column 0
+    most significant, numeric per column). Hence an input already sorted in that order yields
+    an ascending key array, so ``np.searchsorted`` on it stays valid. Charge blocks are small
+    integers with few distinct values per column, so the key space usually fits comfortably.
+    """
+    cp = tsets[0].shape[1]
+    sizes = [len(t) for t in tsets]
+    if cp == 0:  # zero-width rows: a single (empty) class
+        keys = np.zeros(sum(sizes), dtype=np.int64)
+    else:
+        stacked = np.concatenate(tsets, axis=0) if len(tsets) > 1 else tsets[0]
+        ranks, radices, prod = [], [], 1
+        for j in range(cp):
+            u, inv = np.unique(stacked[:, j], return_inverse=True)  # per-column ranks preserve order
+            ranks.append(inv.reshape(-1))
+            radices.append(len(u))
+            prod *= len(u)
+            if prod >= (1 << 62):
+                return None
+        keys = np.zeros(sum(sizes), dtype=np.int64)
+        w = 1
+        for j in range(cp - 1, -1, -1):  # column 0 carries the largest weight (most significant)
+            keys += ranks[j] * w
+            w *= radices[j]
+    out, off = [], 0
+    for s in sizes:
+        out.append(keys[off: off + s])
+        off += s
+    return out
+
+
+def _row_keys_pair(t1, t2):
+    """
+    A comparable-and-searchsortable 1-D key per row of ``t1`` / ``t2`` (same #columns).
+    Uses the fast order-preserving int64 encoding, falling back to a structured-dtype view
+    of the raw rows when the int64 key space would overflow. In both cases keys of ``t1`` and
+    ``t2`` share an ordering, and ``t1`` sorted by rows implies its keys are ascending.
+    """
+    enc = _encode_rows_shared([t1, t2])
+    if enc is not None:
+        return enc[0], enc[1]
+    struct_dt = np.dtype([('', t1.dtype)] * t1.shape[1])
+    return (np.ascontiguousarray(t1).view(struct_dt).ravel(),
+            np.ascontiguousarray(t2).view(struct_dt).ravel())
+
+
 @nsys_profile
 def find_matching_indices(tset1, tset2, both=True):
     rs1, *cs1 = tset1.shape
@@ -437,16 +491,11 @@ def find_matching_indices(tset1, tset2, both=True):
     if cp == 0 and rs1 == 1 and rs2 == 1:
         ind1 = ind2 = np.array([0], dtype=np.int64)
     elif cp > 0 and rs1 > 0 and rs2 > 0:
-        tset1 = tset1.reshape(rs1, cp)
-        tset2 = tset2.reshape(rs2, cp)
-        struct_dt = np.dtype([('', tset1.dtype)] * cp)
-        tset1_view = np.ascontiguousarray(tset1).view(struct_dt).ravel()
-        tset2_view = np.ascontiguousarray(tset2).view(struct_dt).ravel()
-
-        ind1 = np.searchsorted(tset1_view, tset2_view)
+        v1, v2 = _row_keys_pair(tset1.reshape(rs1, cp), tset2.reshape(rs2, cp))
+        ind1 = np.searchsorted(v1, v2)
         mask = ind1 < rs1
         safe_ind = np.where(mask, ind1, 0)
-        mask = mask & (tset1_view[safe_ind] == tset2_view)
+        mask = mask & (v1[safe_ind] == v2)
         ind1 = ind1[mask]
         if both:
             ind2 = np.flatnonzero(mask)
@@ -455,33 +504,3 @@ def find_matching_indices(tset1, tset2, both=True):
     return (ind1, ind2) if both else ind1
 
 
-@nsys_profile
-def locate_rows(tset, query):
-    """
-    Index of each row of ``query`` within ``tset``, or ``len(tset)`` when the row is absent.
-
-    ``tset`` must have unique rows sorted in the same (per-column, lexicographic) order
-    produced by ``np.unique(..., axis=0)``; ``query`` may contain arbitrary/repeated rows.
-    Unlike :func:`find_matching_indices`, the result has one entry per row of ``query``
-    (misses flagged with the sentinel ``len(tset)``), so it maps rows to their class id.
-    """
-    rs, *cs = tset.shape
-    rq, *cq = query.shape
-    assert cs == cq, "Sanity check. Contact developers."
-    cp = np.prod(cs, dtype=np.int64)
-    if rs == 0:  # empty tset: every query row is absent
-        return np.full(rq, rs, dtype=np.int64)
-    if cp == 0:  # zero-width rows collapse to a single (empty) class present in tset
-        return np.zeros(rq, dtype=np.int64)
-    tset = tset.reshape(rs, cp)
-    query = query.reshape(rq, cp)
-    struct_dt = np.dtype([('', tset.dtype)] * cp)
-    tset_view = np.ascontiguousarray(tset).view(struct_dt).ravel()
-    query_view = np.ascontiguousarray(query).view(struct_dt).ravel()
-
-    ids = np.searchsorted(tset_view, query_view)
-    hit = ids < rs
-    safe_ind = np.where(hit, ids, 0)
-    hit &= tset_view[safe_ind] == query_view
-    ids[~hit] = rs  # sentinel for rows absent from tset
-    return ids

--- a/yastn/tensor/_contractions.py
+++ b/yastn/tensor/_contractions.py
@@ -28,6 +28,7 @@ from ._auxiliary import _encode_rows_shared, _row_keys_pair, _struct, _clear_axe
 from ._auxiliary import find_matching_indices, argsort_t, get_blocks, hash_blocks, get_trimmed_struct
 from ._merging import _unfuse_blocks, _fuse_blocks, _mask_tensors_leg_intersection, _meta_mask
 from ._tests import YastnError, _test_can_be_combined, _unpack_trans_test_axes_pair
+from ..backend import import_backend
 
 if TYPE_CHECKING:
     from . import Tensor
@@ -530,7 +531,8 @@ def _meta_tensordot_cutensor(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout
     """ Dispatch to the optimized CPU or GPU _meta_tensordot_cutensor builder. 
     ``device`` (the first operand's data device) is used only by GPU. """
     
-    if policy in ["gpu",] or ((policy in ["auto"] and device) or _META_CUTENSOR_VERSION in ["gpu",]):
+    if policy in ["gpu",] or ((policy in ["auto"] and not import_backend(backend_id).is_cpu_device(device)) \
+                              or _META_CUTENSOR_VERSION in ["gpu",]):
         from ._contractions_cutensor import _meta_tensordot_cutensor_gpu  # lazy: avoids import cycle
         meta= _meta_tensordot_cutensor_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, 
                     lazy_threshold=lazy_threshold, device=device, backend_id=backend_id)

--- a/yastn/tensor/_contractions.py
+++ b/yastn/tensor/_contractions.py
@@ -19,12 +19,12 @@ import abc
 import os
 from functools import lru_cache
 from numbers import Number
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, Union
 
 import numpy as np
 
 from .._profile import nsys_profile, nvtx_range
-from ._auxiliary import _struct, _clear_axes, _unpack_axes, sign_canonical_order, _compress_slices
+from ._auxiliary import _encode_rows_shared, _row_keys_pair, _struct, _clear_axes, _unpack_axes, sign_canonical_order, _compress_slices
 from ._auxiliary import find_matching_indices, argsort_t, get_blocks, hash_blocks, get_trimmed_struct
 from ._merging import _unfuse_blocks, _fuse_blocks, _mask_tensors_leg_intersection, _meta_mask
 from ._tests import YastnError, _test_can_be_combined, _unpack_trans_test_axes_pair
@@ -222,9 +222,11 @@ def _remap_nout_(nout, offset):
 @nsys_profile
 def _tensordot_cutensor(a, b, nout_a, nin_a, nin_b, nout_b, lazy_threshold):
     struct_c, size_c, hash_a, hash_b, hash_c, *metas = \
-        _meta_tensordot_cutensor(a.config.sym, a.struct, b.struct, nout_a, nin_a, nin_b, nout_b, lazy_threshold, a.data.device)
+        _meta_tensordot_cutensor(a.config.sym, a.struct, b.struct, nout_a, nin_a, nin_b, nout_b, 
+            lazy_threshold=lazy_threshold, policy=a.config.meta_tensordot_policy, 
+            device=a.device, backend_id=a.config.backend.BACKEND_ID)
     if size_c == 0:
-        data = a.config.backend.zeros((0,), dtype=a.yastn_dtype, device=a.data.device)
+        data = a.config.backend.zeros((0,), dtype=a.yastn_dtype, device=a.device)
         return data, struct_c
 
     dot_product= len(nout_a)+len(nout_b) == 0
@@ -516,30 +518,82 @@ def _match_legs_tensordot(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
 
 
 # A/B toggle for the cutensor tensordot meta builder.
-#   v1 -- preserved original: structured/void np.unique + find_matching_indices (this module).
-#   v2 -- optimized: order-preserving int64-key encoding, in ._contractions_cutensor.
 # Both share leg-matching, block enumeration, the "align charge indices" step and the
 # backend-meta finalization (kept here); they differ only in "unique out blocks" and "mask c".
-# Select with env YASTN_META_CUTENSOR_V=1|2 (default 2), or set the module global
-# _META_CUTENSOR_VERSION at runtime (each version is independently lru_cached).
-_META_CUTENSOR_VERSION = int(os.environ.get("YASTN_META_CUTENSOR_V", "2"))
+# Override default choice "auto" with YASTN_META_CUTENSOR=CPU|GPU. Each version is independently lru_cached.
+_META_CUTENSOR_VERSION = os.environ.get("YASTN_META_CUTENSOR", "AUTO").lower()
 
 
-def _meta_tensordot_cutensor(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, lazy_threshold=None, device=None):
-    """ Dispatch to the preserved-original (v1), optimized CPU (v2) or GPU (v3) cutensor meta
-    builder. ``device`` (the first operand's data device) is used only by v3. """
-    if _META_CUTENSOR_VERSION == 1:
-        return _meta_tensordot_cutensor_v1(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, lazy_threshold)
-    if _META_CUTENSOR_VERSION == 3:
-        from ._contractions_cutensor import _meta_tensordot_cutensor_v3  # lazy: avoids import cycle
-        return _meta_tensordot_cutensor_v3(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device)
-    from ._contractions_cutensor import _meta_tensordot_cutensor_v2  # lazy: avoids import cycle
-    return _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+def _meta_tensordot_cutensor(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, 
+                             lazy_threshold:float=None, policy:str=None,
+                             device:str=None, backend_id:str=None):
+    """ Dispatch to the optimized CPU or GPU _meta_tensordot_cutensor builder. 
+    ``device`` (the first operand's data device) is used only by GPU. """
+    
+    if policy in ["gpu",] or ((policy in ["auto"] and device) or _META_CUTENSOR_VERSION in ["gpu",]):
+        from ._contractions_cutensor import _meta_tensordot_cutensor_gpu  # lazy: avoids import cycle
+        meta= _meta_tensordot_cutensor_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, 
+                    lazy_threshold=lazy_threshold, device=device, backend_id=backend_id)
+        if meta is not None:
+            return meta
+        # int64 overflow in optimized mask construction; fall back to CPU version
+    return _meta_tensordot_cutensor_cpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, lazy_threshold)
+
+
+@nsys_profile
+def locate_rows(tset, query):
+    """
+    Index of each row of ``query`` within ``tset``, or ``len(tset)`` when the row is absent.
+
+    ``tset`` must have unique rows sorted in the same (per-column, lexicographic) order
+    produced by ``np.unique(..., axis=0)``; ``query`` may contain arbitrary/repeated rows.
+    Unlike :func:`yastn.tensor._auxiliary.find_matching_indices`, the result has one entry
+    per row of ``query`` (misses flagged with the sentinel ``len(tset)``), so it maps rows
+    to their class id.
+    """
+    rs, *cs = tset.shape
+    rq, *cq = query.shape
+    assert cs == cq, "Sanity check. Contact developers."
+    cp = np.prod(cs, dtype=np.int64)
+    if rs == 0:  # empty tset: every query row is absent
+        return np.full(rq, rs, dtype=np.int64)
+    if cp == 0:  # zero-width rows collapse to a single (empty) class present in tset
+        return np.zeros(rq, dtype=np.int64)
+    v_t, v_q = _row_keys_pair(tset.reshape(rs, cp), query.reshape(rq, cp))
+    ids = np.searchsorted(v_t, v_q)
+    hit = ids < rs
+    safe_ind = np.where(hit, ids, 0)
+    hit &= v_t[safe_ind] == v_q
+    ids[~hit] = rs  # sentinel for rows absent from tset
+    return ids
+
+
+def unique_rows(t, return_inverse=False, return_counts=False):
+    """
+    Drop-in accelerator for ``np.unique(t, axis=0, ...)`` on integer charge blocks.
+
+    Encodes rows as order-preserving int64 keys and uniques those in 1-D, which is markedly
+    faster than numpy's structured/void ``axis=0`` sort; falls back to ``np.unique(axis=0)``
+    when the key space would overflow. Returns rows in the same order as ``np.unique(axis=0)``
+    and preserves the input's row shape ``t.shape[1:]``.
+    """
+    rs = t.shape[0]
+    cp = int(np.prod(t.shape[1:], dtype=np.int64))
+    enc = _encode_rows_shared([t.reshape(rs, cp)]) if rs > 0 else None
+    if enc is None:
+        return np.unique(t, axis=0, return_inverse=return_inverse, return_counts=return_counts)
+    uk, first, inv, cnt = np.unique(enc[0], return_index=True, return_inverse=True, return_counts=True)
+    res = [t[first]]  # representative row per class, in key-sorted (== structured-sorted) order
+    if return_inverse:
+        res.append(inv.reshape(-1))
+    if return_counts:
+        res.append(cnt)
+    return res[0] if len(res) == 1 else tuple(res)
 
 
 @lru_cache(maxsize=1024)
 @nsys_profile
-def _meta_tensordot_cutensor_v1(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, lazy_threshold=None):
+def _meta_tensordot_cutensor_cpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, lazy_threshold=None):
     struct_a_sub, struct_b_sub, struct_c = _match_legs_tensordot(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
     bl_a, slc_a = get_blocks_and_subslices(sym, struct_a_sub, struct_a)
     bl_b, slc_b = get_blocks_and_subslices(sym, struct_b_sub, struct_b)
@@ -547,25 +601,34 @@ def _meta_tensordot_cutensor_v1(sym, struct_a, struct_b, nout_a, nin_a, nin_b, n
     
     if lazy_threshold and bl_c.nblocks:
         with nvtx_range("unique in blocks"):
-            # if more blocks of a contribute to given contracted sector (in b)
-            unique_a, inv_a, count_a = np.unique(bl_a.t[:, nin_a, :], return_inverse=True, return_counts=True, axis=0)
+            unique_a, inv_a, count_a = unique_rows(bl_a.t[:, nin_a, :], return_inverse=True, return_counts=True) # if more blocks of a contribute to given contracted sector (in b)
             arg_a = np.argsort(inv_a)
             #
-            unique_b, inv_b, count_b = np.unique(bl_b.t[:, nin_b, :], return_inverse=True, return_counts=True, axis=0)
+            unique_b, inv_b, count_b = unique_rows(bl_b.t[:, nin_b, :], return_inverse=True, return_counts=True)
             arg_b = np.argsort(inv_b)
         #
         ind_a, ind_b = _matched_pair_indices(unique_a, count_a, arg_a, unique_b, count_b, arg_b)
         #
         with nvtx_range("unique out blocks"):
-            tao = bl_a.t[:, nout_a, :]
-            tbo = bl_b.t[:, nout_b, :]
-            tn = np.column_stack([tao[ind_a], tbo[ind_b]])
-            unique_c, inv_c = np.unique(tn, return_inverse=True, axis=0)
+            # A candidate output block of bl_c is produced iff its (out_a, out_b) charge tuple
+            # arises from some matched (a, b) pair. Encode each out_a / out_b tuple as a small
+            # integer id (one class per distinct tuple among the blocks) and reduce the per-pair
+            # test to 1-D int64 operations. This avoids building and sorting the ~nn wide rows
+            # that column_stack + np.unique(axis=0) would otherwise require (nn = matched pairs).
+            na, nb, nsym = len(nout_a), len(nout_b), bl_a.t.shape[2]  # explicit widths: bl_*.nblocks may be 0
+            ua, id_a = unique_rows(bl_a.t[:, nout_a, :].reshape(bl_a.nblocks, na * nsym), return_inverse=True)
+            ub, id_b = unique_rows(bl_b.t[:, nout_b, :].reshape(bl_b.nblocks, nb * nsym), return_inverse=True)
+            id_a, id_b, n_b = id_a.reshape(-1), id_b.reshape(-1), len(ub)
             #
-            ind_c = find_matching_indices(bl_c.t, unique_c, both=False)
+            keys = np.unique(id_a[ind_a] * n_b + id_b[ind_b])  # produced (out_a, out_b) classes
             #
-            mask = np.zeros(bl_c.nblocks, dtype=bool)
-            mask[ind_c] = True
+            # struct_c legs are ordered (out_a from nout_a, then out_b from nout_b), so bl_c.t
+            # splits into its out_a (:na) and out_b (na:) columns aligned with ua / ub above
+            cid_a = locate_rows(ua, bl_c.t[:, :na, :].reshape(bl_c.nblocks, na * nsym))
+            cid_b = locate_rows(ub, bl_c.t[:, na:, :].reshape(bl_c.nblocks, nb * nsym))
+            c_keys = np.where((cid_a < len(ua)) & (cid_b < n_b), cid_a * n_b + cid_b, -1)
+            #
+            mask = np.isin(c_keys, keys)  # -1 sentinel (tuple absent from a/b blocks) never matches
             struct_c = struct_c.replace(mask=mask)
             bl_c = get_blocks(sym, struct_c)
     

--- a/yastn/tensor/_contractions.py
+++ b/yastn/tensor/_contractions.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import abc
+import os
 from functools import lru_cache
 from numbers import Number
 from typing import TYPE_CHECKING, NamedTuple
@@ -24,7 +25,7 @@ import numpy as np
 
 from .._profile import nsys_profile, nvtx_range
 from ._auxiliary import _struct, _clear_axes, _unpack_axes, sign_canonical_order, _compress_slices
-from ._auxiliary import find_matching_indices, locate_rows, argsort_t, get_blocks, hash_blocks, get_trimmed_struct
+from ._auxiliary import find_matching_indices, argsort_t, get_blocks, hash_blocks, get_trimmed_struct
 from ._merging import _unfuse_blocks, _fuse_blocks, _mask_tensors_leg_intersection, _meta_mask
 from ._tests import YastnError, _test_can_be_combined, _unpack_trans_test_axes_pair
 
@@ -394,11 +395,13 @@ def _meta_tensordot_nf(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b):
     reshape_b = reshape_b.view(rb_dt).reshape(-1)
     return meta, reshape_a, reshape_b, bl_c.size, struct_c
 
+
 class _cutensor_meta(NamedTuple):
     numSectionsPerMode: np.ndarray
     sectionExtents: np.ndarray
     coords: np.ndarray
     strides: np.ndarray
+
 
 @nsys_profile
 def _convert_bl_for_cutensor(struct, bl, slc=None, dot_product=False):
@@ -435,80 +438,20 @@ def _convert_bl_for_cutensor(struct, bl, slc=None, dot_product=False):
     return numSectionsPerMode, sectionExtents, coords, strides, offsets
 
 
-@lru_cache(maxsize=1024)
 @nsys_profile
-def _meta_tensordot_cutensor(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b):
+def _matched_pair_indices(unique_a, count_a, arg_a, unique_b, count_b, arg_b):
+    """ Block-index lists (ind_a, ind_b) of every matching (a, b) pair, aligned by contracted
+    charge sector (counts padded with zeros to line up matching charges). """
+    unique_ab = np.unique(np.vstack([unique_a, unique_b]), axis=0)
+    in_a = find_matching_indices(unique_ab, unique_a, both=False)
+    in_b = find_matching_indices(unique_ab, unique_b, both=False)
+    count_a2 = np.zeros(len(unique_ab), dtype=np.int64)
+    count_a2[in_a] = count_a
+    count_b2 = np.zeros(len(unique_ab), dtype=np.int64)
+    count_b2[in_b] = count_b
     #
-    struct_a_sub, struct_b_sub, struct_c = _match_legs_tensordot(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
-    bl_a, slc_a = get_blocks_and_subslices(sym, struct_a_sub, struct_a)
-    bl_b, slc_b = get_blocks_and_subslices(sym, struct_b_sub, struct_b)
-    bl_c = get_blocks(sym, struct_c)
-    
-    with nvtx_range("unique out blocks"):
-        unique_a, inv_a, count_a = np.unique(bl_a.t[:, nin_a, :], return_inverse=True, return_counts=True, axis=0) # if more blocks of a contribute to given contracted sector (in b)
-        arg_a = np.argsort(inv_a)
-        #
-        unique_b, inv_b, count_b = np.unique(bl_b.t[:, nin_b, :], return_inverse=True, return_counts=True, axis=0)
-        arg_b = np.argsort(inv_b)
-    #
-    # padding count_a and count_b with zero to allign matching charges
-    with nvtx_range("align charge indices"):
-        unique_ab = np.unique(np.vstack([unique_a, unique_b]), axis=0)
-        in_a = find_matching_indices(unique_ab, unique_a, both=False)
-        in_b = find_matching_indices(unique_ab, unique_b, both=False)
-        count_a2 = np.zeros(len(unique_ab), dtype=np.int64)
-        count_a2[in_a] = count_a
-        count_b2 = np.zeros(len(unique_ab), dtype=np.int64)
-        count_b2[in_b] = count_b
-        #
-        ind_a, ind_b = _indices_from_counts(count_a2, count_b2)
-        ind_a = arg_a[ind_a]
-        ind_b = arg_b[ind_b]
-    #
-    with nvtx_range("mask c"):
-        # A candidate output block of bl_c is produced iff its (out_a, out_b) charge tuple
-        # arises from some matched (a, b) pair. Encode each out_a / out_b tuple as a small
-        # integer id (one class per distinct tuple among the blocks) and reduce the per-pair
-        # test to 1-D int64 operations. This avoids building and sorting the ~nn wide rows
-        # that column_stack + np.unique(axis=0) would otherwise require (nn = matched pairs).
-        na, nb, nsym = len(nout_a), len(nout_b), bl_a.t.shape[2]  # explicit widths: bl_*.nblocks may be 0
-        ua, id_a = np.unique(bl_a.t[:, nout_a, :].reshape(bl_a.nblocks, na * nsym), axis=0, return_inverse=True)
-        ub, id_b = np.unique(bl_b.t[:, nout_b, :].reshape(bl_b.nblocks, nb * nsym), axis=0, return_inverse=True)
-        id_a, id_b, n_b = id_a.reshape(-1), id_b.reshape(-1), len(ub)
-        #
-        keys = np.unique(id_a[ind_a] * n_b + id_b[ind_b])  # produced (out_a, out_b) classes
-        #
-        # struct_c legs are ordered (out_a from nout_a, then out_b from nout_b), so bl_c.t
-        # splits into its out_a (:na) and out_b (na:) columns aligned with ua / ub above
-        cid_a = locate_rows(ua, bl_c.t[:, :na, :].reshape(bl_c.nblocks, na * nsym))
-        cid_b = locate_rows(ub, bl_c.t[:, na:, :].reshape(bl_c.nblocks, nb * nsym))
-        c_keys = np.where((cid_a < len(ua)) & (cid_b < n_b), cid_a * n_b + cid_b, -1)
-        #
-        mask = np.isin(c_keys, keys)  # -1 sentinel (tuple absent from a/b blocks) never matches
-        struct_c = struct_c.replace(mask=mask)
-        bl_c = get_blocks(sym, struct_c)
-    #
-    # dot product, which cannot be simply dispatched to vdot
-    #              and either one of operands is (effectively) zero
-    if not (len(slc_a) > 0 and len(slc_b) > 0):
-        return struct_c, 0, *([None] * 18)
-    else:
-        dot_product = len(nout_a) + len(nout_b) == 0
-        a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets = \
-            _convert_bl_for_cutensor(struct_a_sub, bl_a, slc_a, dot_product=(dot_product and len(slc_a) < len(slc_b)))
-        b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets = \
-            _convert_bl_for_cutensor(struct_b_sub, bl_b, slc_b, dot_product=(dot_product and len(slc_a) >= len(slc_b)))
-        c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets = \
-            _convert_bl_for_cutensor(struct_c, bl_c, dot_product=dot_product)
-
-        h_a, h_b, h_c = hash_blocks(_cutensor_meta(a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides), out=bytes),\
-                    hash_blocks(_cutensor_meta(b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides), out=bytes),\
-                    hash_blocks(_cutensor_meta(c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides), out=bytes)
-
-    return (struct_c, bl_c.size, h_a, h_b, h_c,
-            a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets,
-            b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets,
-            c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets)
+    ind_a, ind_b = _indices_from_counts(count_a2, count_b2)
+    return arg_a[ind_a], arg_b[ind_b]
 
 
 @nsys_profile
@@ -546,6 +489,78 @@ def _match_legs_tensordot(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
             legs_b_new[ax] = struct_c_1.legs[ii].intersection(struct_b_1.legs[ax])
 
     return struct_a_1, struct_b_1, struct_c_1
+
+
+# A/B toggle for the cutensor tensordot meta builder.
+#   v1 -- preserved original: structured/void np.unique + find_matching_indices (this module).
+#   v2 -- optimized: order-preserving int64-key encoding, in ._contractions_cutensor.
+# Both share leg-matching, block enumeration, the "align charge indices" step and the
+# backend-meta finalization (kept here); they differ only in "unique out blocks" and "mask c".
+# Select with env YASTN_META_CUTENSOR_V=1|2 (default 2), or set the module global
+# _META_CUTENSOR_VERSION at runtime (each version is independently lru_cached).
+_META_CUTENSOR_VERSION = int(os.environ.get("YASTN_META_CUTENSOR_V", "2"))
+
+
+def _meta_tensordot_cutensor(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b):
+    """ Dispatch to the preserved-original (v1) or optimized (v2) cutensor meta builder. """
+    if _META_CUTENSOR_VERSION == 1:
+        return _meta_tensordot_cutensor_v1(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+    from ._contractions_cutensor import _meta_tensordot_cutensor_v2  # lazy: avoids import cycle
+    return _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+
+
+@lru_cache(maxsize=1024)
+@nsys_profile
+def _meta_tensordot_cutensor_v1(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b):
+    struct_a_sub, struct_b_sub, struct_c = _match_legs_tensordot(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+    bl_a, slc_a = get_blocks_and_subslices(sym, struct_a_sub, struct_a)
+    bl_b, slc_b = get_blocks_and_subslices(sym, struct_b_sub, struct_b)
+    bl_c = get_blocks(sym, struct_c)
+    
+    with nvtx_range("unique in blocks"):
+        # if more blocks of a contribute to given contracted sector (in b)
+        unique_a, inv_a, count_a = np.unique(bl_a.t[:, nin_a, :], return_inverse=True, return_counts=True, axis=0)
+        arg_a = np.argsort(inv_a)
+        #
+        unique_b, inv_b, count_b = np.unique(bl_b.t[:, nin_b, :], return_inverse=True, return_counts=True, axis=0)
+        arg_b = np.argsort(inv_b)
+    #
+    ind_a, ind_b = _matched_pair_indices(unique_a, count_a, arg_a, unique_b, count_b, arg_b)
+    #
+    with nvtx_range("unique out blocks"):
+        tao = bl_a.t[:, nout_a, :]
+        tbo = bl_b.t[:, nout_b, :]
+        tn = np.column_stack([tao[ind_a], tbo[ind_b]])
+        unique_c, inv_c = np.unique(tn, return_inverse=True, axis=0)
+        #
+        ind_c = find_matching_indices(bl_c.t, unique_c, both=False)
+        #
+        mask = np.zeros(bl_c.nblocks, dtype=bool)
+        mask[ind_c] = True
+        struct_c = struct_c.replace(mask=mask)
+        bl_c = get_blocks(sym, struct_c)
+    
+    # dot product, which cannot be simply dispatched to vdot
+    #              and either one of operands is (effectively) zero
+    if not (len(slc_a) > 0 and len(slc_b) > 0):
+        return struct_c, 0, *([None] * 18)
+    else:
+        dot_product = len(nout_a) + len(nout_b) == 0
+        a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets = \
+            _convert_bl_for_cutensor(struct_a_sub, bl_a, slc_a, dot_product=(dot_product and len(slc_a) < len(slc_b)))
+        b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets = \
+            _convert_bl_for_cutensor(struct_b_sub, bl_b, slc_b, dot_product=(dot_product and len(slc_a) >= len(slc_b)))
+        c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets = \
+            _convert_bl_for_cutensor(struct_c, bl_c, dot_product=dot_product)
+
+        h_a, h_b, h_c = hash_blocks(_cutensor_meta(a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides), out=bytes),\
+                    hash_blocks(_cutensor_meta(b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides), out=bytes),\
+                    hash_blocks(_cutensor_meta(c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides), out=bytes)
+
+    return (struct_c, bl_c.size, h_a, h_b, h_c,
+            a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets,
+            b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets,
+            c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets)
 
 
 def get_blocks_and_subslices(sym, struct_sub, struct_full):

--- a/yastn/tensor/_contractions.py
+++ b/yastn/tensor/_contractions.py
@@ -209,7 +209,7 @@ def _remap_nout_(nout, offset):
 @nsys_profile
 def _tensordot_cutensor(a, b, nout_a, nin_a, nin_b, nout_b):
     struct_c, size_c, hash_a, hash_b, hash_c, *metas = \
-        _meta_tensordot_cutensor(a.config.sym, a.struct, b.struct, nout_a, nin_a, nin_b, nout_b)
+        _meta_tensordot_cutensor(a.config.sym, a.struct, b.struct, nout_a, nin_a, nin_b, nout_b, a.data.device)
     if size_c == 0:
         data = a.config.backend.zeros((0,), dtype=a.yastn_dtype, device=a.data.device)
         return data, struct_c
@@ -501,10 +501,14 @@ def _match_legs_tensordot(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
 _META_CUTENSOR_VERSION = int(os.environ.get("YASTN_META_CUTENSOR_V", "2"))
 
 
-def _meta_tensordot_cutensor(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b):
-    """ Dispatch to the preserved-original (v1) or optimized (v2) cutensor meta builder. """
+def _meta_tensordot_cutensor(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device=None):
+    """ Dispatch to the preserved-original (v1), optimized CPU (v2) or GPU (v3) cutensor meta
+    builder. ``device`` (the first operand's data device) is used only by v3. """
     if _META_CUTENSOR_VERSION == 1:
         return _meta_tensordot_cutensor_v1(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+    if _META_CUTENSOR_VERSION == 3:
+        from ._contractions_cutensor import _meta_tensordot_cutensor_v3  # lazy: avoids import cycle
+        return _meta_tensordot_cutensor_v3(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device)
     from ._contractions_cutensor import _meta_tensordot_cutensor_v2  # lazy: avoids import cycle
     return _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
 

--- a/yastn/tensor/_contractions_cutensor.py
+++ b/yastn/tensor/_contractions_cutensor.py
@@ -36,156 +36,44 @@ from ._auxiliary import (_encode_rows_shared, _row_keys_pair, get_blocks, hash_b
 from ._contractions import (_convert_bl_for_cutensor, _cutensor_meta, _match_legs_tensordot,
                             get_blocks_and_subslices, _matched_pair_indices,)
 from ._tests import YastnError
+from ..backend import import_backend
 
-#: Below this many rows the GPU (v3) matcher / mask fall back to numpy (launch+transfer
+#: Below this many rows the GPU matcher / mask fall back to numpy (launch+transfer
 #: overhead dominates). Tunable via env ``YASTN_META_CUTENSOR_GPU_MIN``.
 _GPU_MIN = int(os.environ.get("YASTN_META_CUTENSOR_GPU_MIN", "4096"))
 
 
-@nsys_profile
-def locate_rows(tset, query):
-    """
-    Index of each row of ``query`` within ``tset``, or ``len(tset)`` when the row is absent.
-
-    ``tset`` must have unique rows sorted in the same (per-column, lexicographic) order
-    produced by ``np.unique(..., axis=0)``; ``query`` may contain arbitrary/repeated rows.
-    Unlike :func:`yastn.tensor._auxiliary.find_matching_indices`, the result has one entry
-    per row of ``query`` (misses flagged with the sentinel ``len(tset)``), so it maps rows
-    to their class id.
-    """
-    rs, *cs = tset.shape
-    rq, *cq = query.shape
-    assert cs == cq, "Sanity check. Contact developers."
-    cp = np.prod(cs, dtype=np.int64)
-    if rs == 0:  # empty tset: every query row is absent
-        return np.full(rq, rs, dtype=np.int64)
-    if cp == 0:  # zero-width rows collapse to a single (empty) class present in tset
-        return np.zeros(rq, dtype=np.int64)
-    v_t, v_q = _row_keys_pair(tset.reshape(rs, cp), query.reshape(rq, cp))
-    ids = np.searchsorted(v_t, v_q)
-    hit = ids < rs
-    safe_ind = np.where(hit, ids, 0)
-    hit &= v_t[safe_ind] == v_q
-    ids[~hit] = rs  # sentinel for rows absent from tset
-    return ids
-
-
-def unique_rows(t, return_inverse=False, return_counts=False):
-    """
-    Drop-in accelerator for ``np.unique(t, axis=0, ...)`` on integer charge blocks.
-
-    Encodes rows as order-preserving int64 keys and uniques those in 1-D, which is markedly
-    faster than numpy's structured/void ``axis=0`` sort; falls back to ``np.unique(axis=0)``
-    when the key space would overflow. Returns rows in the same order as ``np.unique(axis=0)``
-    and preserves the input's row shape ``t.shape[1:]``.
-    """
-    rs = t.shape[0]
-    cp = int(np.prod(t.shape[1:], dtype=np.int64))
-    enc = _encode_rows_shared([t.reshape(rs, cp)]) if rs > 0 else None
-    if enc is None:
-        return np.unique(t, axis=0, return_inverse=return_inverse, return_counts=return_counts)
-    uk, first, inv, cnt = np.unique(enc[0], return_index=True, return_inverse=True, return_counts=True)
-    res = [t[first]]  # representative row per class, in key-sorted (== structured-sorted) order
-    if return_inverse:
-        res.append(inv.reshape(-1))
-    if return_counts:
-        res.append(cnt)
-    return res[0] if len(res) == 1 else tuple(res)
-
-
-@lru_cache(maxsize=1024)
-@nsys_profile
-def _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, lazy_threshold=None):
-    struct_a_sub, struct_b_sub, struct_c = _match_legs_tensordot(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
-    bl_a, slc_a = get_blocks_and_subslices(sym, struct_a_sub, struct_a)
-    bl_b, slc_b = get_blocks_and_subslices(sym, struct_b_sub, struct_b)
-    bl_c = get_blocks(sym, struct_c)
-    
-    if lazy_threshold and bl_c.nblocks:
-        with nvtx_range("unique in blocks"):
-            unique_a, inv_a, count_a = unique_rows(bl_a.t[:, nin_a, :], return_inverse=True, return_counts=True) # if more blocks of a contribute to given contracted sector (in b)
-            arg_a = np.argsort(inv_a)
-            #
-            unique_b, inv_b, count_b = unique_rows(bl_b.t[:, nin_b, :], return_inverse=True, return_counts=True)
-            arg_b = np.argsort(inv_b)
-        #
-        ind_a, ind_b = _matched_pair_indices(unique_a, count_a, arg_a, unique_b, count_b, arg_b)
-        #
-        with nvtx_range("unique out blocks"):
-            # A candidate output block of bl_c is produced iff its (out_a, out_b) charge tuple
-            # arises from some matched (a, b) pair. Encode each out_a / out_b tuple as a small
-            # integer id (one class per distinct tuple among the blocks) and reduce the per-pair
-            # test to 1-D int64 operations. This avoids building and sorting the ~nn wide rows
-            # that column_stack + np.unique(axis=0) would otherwise require (nn = matched pairs).
-            na, nb, nsym = len(nout_a), len(nout_b), bl_a.t.shape[2]  # explicit widths: bl_*.nblocks may be 0
-            ua, id_a = unique_rows(bl_a.t[:, nout_a, :].reshape(bl_a.nblocks, na * nsym), return_inverse=True)
-            ub, id_b = unique_rows(bl_b.t[:, nout_b, :].reshape(bl_b.nblocks, nb * nsym), return_inverse=True)
-            id_a, id_b, n_b = id_a.reshape(-1), id_b.reshape(-1), len(ub)
-            #
-            keys = np.unique(id_a[ind_a] * n_b + id_b[ind_b])  # produced (out_a, out_b) classes
-            #
-            # struct_c legs are ordered (out_a from nout_a, then out_b from nout_b), so bl_c.t
-            # splits into its out_a (:na) and out_b (na:) columns aligned with ua / ub above
-            cid_a = locate_rows(ua, bl_c.t[:, :na, :].reshape(bl_c.nblocks, na * nsym))
-            cid_b = locate_rows(ub, bl_c.t[:, na:, :].reshape(bl_c.nblocks, nb * nsym))
-            c_keys = np.where((cid_a < len(ua)) & (cid_b < n_b), cid_a * n_b + cid_b, -1)
-            #
-            mask = np.isin(c_keys, keys)  # -1 sentinel (tuple absent from a/b blocks) never matches
-            struct_c = struct_c.replace(mask=mask)
-            bl_c = get_blocks(sym, struct_c)
-    
-    # dot product, which cannot be simply dispatched to vdot
-    #              and either one of operands is (effectively) zero
-    if not (len(slc_a) > 0 and len(slc_b) > 0):
-        return struct_c, 0, *([None] * 18)
-    else:
-        dot_product = len(nout_a) + len(nout_b) == 0
-        a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets = \
-            _convert_bl_for_cutensor(struct_a_sub, bl_a, slc_a, dot_product=(dot_product and len(slc_a) < len(slc_b)))
-        b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets = \
-            _convert_bl_for_cutensor(struct_b_sub, bl_b, slc_b, dot_product=(dot_product and len(slc_a) >= len(slc_b)))
-        c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets = \
-            _convert_bl_for_cutensor(struct_c, bl_c, dot_product=dot_product)
-
-        h_a, h_b, h_c = hash_blocks(_cutensor_meta(a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides), out=bytes),\
-                    hash_blocks(_cutensor_meta(b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides), out=bytes),\
-                    hash_blocks(_cutensor_meta(c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides), out=bytes)
-
-    return (struct_c, bl_c.size, h_a, h_b, h_c,
-            a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets,
-            b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets,
-            c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets)
-
-
 # =====================================================================================
-# GPU (v3) path. torch is imported lazily *inside* functions so that ``import yastn`` and
-# ``_control_lru`` (which imports this module) never pull torch for numpy-only users.
+# GPU path. The concrete array backend (torch now; cupy/jax in future) is loaded from
+# ``backend_id`` via :func:`import_backend` *inside* the entrypoint and injected into the
+# helpers below, so ``import yastn`` and ``_control_lru`` (which imports this module) never
+# pull a framework for numpy-only users. The helpers use only backend-agnostic primitives
+# (numpy-aligned names on the backend module) plus universal array methods/operators.
 # The shared find_matching_indices and trimming stay untouched; v3 uses its own GPU copies.
 # =====================================================================================
 
 
-def _enc_torch(tsets, torch):
+def _enc_rows(tsets, backend, device):
     """
-    torch twin of :func:`_encode_rows_shared`: order-preserving int64 mixed-radix keys per row
+    Backend twin of :func:`_encode_rows_shared`: order-preserving int64 mixed-radix keys per row
     of each 2-D tensor in ``tsets`` (shared per-column value set), or ``None`` on int64 overflow.
     """
     cp = tsets[0].shape[1]
     sizes = [t.shape[0] for t in tsets]
-    dev = tsets[0].device
     if cp == 0:
-        keys = torch.zeros(sum(sizes), dtype=torch.int64, device=dev)
+        keys = backend.zeros(sum(sizes), dtype='int64', device=device)
     else:
-        stacked = torch.cat(tsets, 0) if len(tsets) > 1 else tsets[0]
+        stacked = backend.concatenate(tsets, axis=0) if len(tsets) > 1 else tsets[0]
         invs, radices, prod = [], [], 1
         for j in range(cp):
-            u, inv = torch.unique(stacked[:, j], return_inverse=True)
-            invs.append(inv.reshape(-1)); radices.append(u.numel()); prod *= u.numel()
+            u, inv = backend.unique(stacked[:, j], return_inverse=True)
+            invs.append(inv.reshape(-1)); radices.append(backend.get_size(u)); prod *= backend.get_size(u)
             if prod >= (1 << 62):
                 return None
-        keys = torch.zeros(sum(sizes), dtype=torch.int64, device=dev)
+        keys = backend.zeros(sum(sizes), dtype='int64', device=device)
         w = 1
         for j in range(cp - 1, -1, -1):  # column 0 most significant (matches np.unique(axis=0))
-            keys += invs[j].to(torch.int64) * w
+            keys += backend.move_to(invs[j], dtype='int64') * w
             w *= radices[j]
     out, off = [], 0
     for s in sizes:
@@ -193,117 +81,114 @@ def _enc_torch(tsets, torch):
     return out
 
 
-def _locate_torch(sorted_u, q, torch):
-    """ torch twin of :func:`locate_rows` on 1-D keys: index of each ``q`` in ``sorted_u`` or
+def _locate(sorted_u, q, backend, device):
+    """ Backend twin of :func:`locate_rows` on 1-D keys: index of each ``q`` in ``sorted_u`` or
     the sentinel ``len(sorted_u)`` when absent. """
-    n = sorted_u.numel()
+    n = backend.get_size(sorted_u)
     if n == 0:
-        return torch.zeros(q.numel(), dtype=torch.int64, device=q.device)  # sentinel 0 == n
-    ids = torch.searchsorted(sorted_u, q)
+        return backend.zeros(backend.get_size(q), dtype='int64', device=device)  # sentinel 0 == n
+    ids = backend.searchsorted(sorted_u, q)
     hit = ids < n
-    safe = torch.where(hit, ids, torch.zeros_like(ids))
+    safe = backend.where(hit, ids, backend.zeros_like(ids))
     hit = hit & (sorted_u[safe] == q)
-    ids = ids.clone()
+    ids = backend.clone(ids)
     ids[~hit] = n
     return ids
 
 
-def _matched_pairs_torch(sa, sb, torch):
+def _matched_pairs(sa, sb, backend, device):
     """
     Block-index lists ``(ind_a, ind_b)`` of every matching (a, b) pair, given the shared-space
-    contracted-sector key of each a-/b-block. torch twin of ``_indices_from_counts`` + the
+    contracted-sector key of each a-/b-block. Backend twin of ``_indices_from_counts`` + the
     ``arg_*`` gather: sort by sector, count per sector, union-align, then a segmented cartesian
     product. Pair order is irrelevant downstream (only the set of produced keys is used).
     """
-    dev = sa.device
-    ord_a = torch.argsort(sa); ord_b = torch.argsort(sb)
-    ua, ca = torch.unique_consecutive(sa[ord_a], return_counts=True)
-    ub, cb = torch.unique_consecutive(sb[ord_b], return_counts=True)
-    starts_a = torch.cumsum(ca, 0) - ca
-    starts_b = torch.cumsum(cb, 0) - cb
-    uni = torch.unique(torch.cat([ua, ub]))
-    pa = torch.searchsorted(uni, ua); pb = torch.searchsorted(uni, ub)
-    ca2 = torch.zeros(uni.numel(), dtype=torch.int64, device=dev); ca2[pa] = ca
-    cb2 = torch.zeros_like(ca2); cb2[pb] = cb
-    sa2 = torch.zeros_like(ca2); sa2[pa] = starts_a
-    sb2 = torch.zeros_like(ca2); sb2[pb] = starts_b
+    ord_a = backend.argsort(sa); ord_b = backend.argsort(sb)
+    ua, ca = backend.unique(sa[ord_a], return_counts=True)  # sorted -> unique == unique_consecutive
+    ub, cb = backend.unique(sb[ord_b], return_counts=True)
+    starts_a = backend.cumsum(ca, axis=0) - ca
+    starts_b = backend.cumsum(cb, axis=0) - cb
+    uni = backend.unique(backend.concatenate([ua, ub]))
+    pa = backend.searchsorted(uni, ua); pb = backend.searchsorted(uni, ub)
+    ca2 = backend.zeros(backend.get_size(uni), dtype='int64', device=device); ca2[pa] = ca
+    cb2 = backend.zeros_like(ca2); cb2[pb] = cb
+    sa2 = backend.zeros_like(ca2); sa2[pa] = starts_a
+    sb2 = backend.zeros_like(ca2); sb2[pb] = starts_b
     prod = ca2 * cb2
-    nn = int(prod.sum().item())
+    nn = int(backend.item(prod.sum()))
     if nn == 0:
-        empty = torch.empty(0, dtype=torch.int64, device=dev)
+        empty = backend.zeros(0, dtype='int64', device=device)
         return empty, empty
-    seg = torch.repeat_interleave(torch.arange(uni.numel(), device=dev), prod)
-    within = torch.arange(nn, device=dev) - (torch.cumsum(prod, 0) - prod)[seg]
+    seg = backend.repeat(backend.arange(backend.get_size(uni), device=device), prod)
+    within = backend.arange(nn, device=device) - (backend.cumsum(prod, axis=0) - prod)[seg]
     cbseg = cb2[seg]
     ind_a = ord_a[sa2[seg] + within // cbseg]
     ind_b = ord_b[sb2[seg] + within % cbseg]
     return ind_a, ind_b
 
 
-def _output_mask_gpu(bl_a, bl_b, bl_c, nout_a, nin_a, nin_b, nout_b, device):
+def _output_mask_gpu(bl_a, bl_b, bl_c, nout_a, nin_a, nin_b, nout_b, device, backend):
     """
     GPU twin of v2's mask-c step: boolean mask (numpy) over ``bl_c`` blocks that are actually
     produced. Only ``bl_*.t`` cross to the device (nn stays on GPU); returns ``None`` on int64
     overflow so the caller can fall back to numpy.
     """
-    import torch
     nba, nbb, nbc = bl_a.nblocks, bl_b.nblocks, bl_c.nblocks
     na, nb = len(nout_a), len(nout_b)
     nsym = bl_a.t.shape[2]
-    ta = torch.as_tensor(bl_a.t, device=device)
-    tb = torch.as_tensor(bl_b.t, device=device)
-    tc = torch.as_tensor(bl_c.t, device=device)
+    ta = backend.to_tensor(bl_a.t, dtype='int64', device=device)
+    tb = backend.to_tensor(bl_b.t, dtype='int64', device=device)
+    tc = backend.to_tensor(bl_c.t, dtype='int64', device=device)
     # contracted-sector keys (shared a/b) -> matched (a, b) pairs
-    enc = _enc_torch([ta[:, nin_a, :].reshape(nba, len(nin_a) * nsym),
-                      tb[:, nin_b, :].reshape(nbb, len(nin_b) * nsym)], torch)
+    enc = _enc_rows([ta[:, nin_a, :].reshape(nba, len(nin_a) * nsym),
+                     tb[:, nin_b, :].reshape(nbb, len(nin_b) * nsym)], backend, device)
     if enc is None:
         return None
-    ind_a, ind_b = _matched_pairs_torch(enc[0], enc[1], torch)
+    ind_a, ind_b = _matched_pairs(enc[0], enc[1], backend, device)
     # out-charge ids: a-out shared with bl_c[:na], b-out shared with bl_c[na:]
-    enca = _enc_torch([ta[:, nout_a, :].reshape(nba, na * nsym),
-                       tc[:, :na, :].reshape(nbc, na * nsym)], torch)
-    encb = _enc_torch([tb[:, nout_b, :].reshape(nbb, nb * nsym),
-                       tc[:, na:, :].reshape(nbc, nb * nsym)], torch)
+    enca = _enc_rows([ta[:, nout_a, :].reshape(nba, na * nsym),
+                      tc[:, :na, :].reshape(nbc, na * nsym)], backend, device)
+    encb = _enc_rows([tb[:, nout_b, :].reshape(nbb, nb * nsym),
+                      tc[:, na:, :].reshape(nbc, nb * nsym)], backend, device)
     if enca is None or encb is None:
         return None
-    ua_keys, id_a = torch.unique(enca[0], return_inverse=True)
-    ub_keys, id_b = torch.unique(encb[0], return_inverse=True)
-    cid_a = _locate_torch(ua_keys, enca[1], torch)
-    cid_b = _locate_torch(ub_keys, encb[1], torch)
-    n_b = ub_keys.numel()
-    keys = torch.unique(id_a.reshape(-1)[ind_a] * n_b + id_b.reshape(-1)[ind_b])
-    valid = (cid_a < ua_keys.numel()) & (cid_b < n_b)
-    c_keys = torch.where(valid, cid_a * n_b + cid_b, torch.full_like(cid_a, -1))
-    return torch.isin(c_keys, keys).cpu().numpy()
+    ua_keys, id_a = backend.unique(enca[0], return_inverse=True)
+    ub_keys, id_b = backend.unique(encb[0], return_inverse=True)
+    cid_a = _locate(ua_keys, enca[1], backend, device)
+    cid_b = _locate(ub_keys, encb[1], backend, device)
+    n_b = backend.get_size(ub_keys)
+    keys = backend.unique(id_a.reshape(-1)[ind_a] * n_b + id_b.reshape(-1)[ind_b])
+    valid = (cid_a < backend.get_size(ua_keys)) & (cid_b < n_b)
+    c_keys = backend.where(valid, cid_a * n_b + cid_b, backend.full_like(cid_a, -1))
+    return backend.to_numpy(backend.isin(c_keys, keys))
 
 
-def _find_matching_indices_gpu(tset1, tset2, both=True, device=None):
+def _find_matching_indices_gpu(tset1, tset2, both=True, device=None, backend=None):
     """
     GPU-accelerated drop-in for :func:`find_matching_indices` (numpy in / numpy out), used only
-    by the v3-local trimming copies. Falls back to the untouched numpy ``find_matching_indices``
-    for cpu device, small inputs, or int64 overflow. ``tset1`` must be sorted-unique (as the
-    numpy version already requires).
+    by the v3-local trimming copies. The device is validated once at the entrypoint, so this
+    assumes a valid GPU ``device``; it still falls back to the untouched numpy
+    ``find_matching_indices`` for small inputs or int64 overflow (perf/correctness, not device
+    validation). ``tset1`` must be sorted-unique (as the numpy version already requires).
     """
     rs1, *cs1 = tset1.shape
     rs2, *cs2 = tset2.shape
     cp = int(np.prod(cs1, dtype=np.int64))
-    if (device is None or getattr(device, 'type', None) != 'cuda'
-            or cp == 0 or rs1 == 0 or rs2 == 0 or max(rs1, rs2) < _GPU_MIN):
+    if cp == 0 or rs1 == 0 or rs2 == 0 or max(rs1, rs2) < _GPU_MIN:
         return find_matching_indices(tset1, tset2, both=both)
-    import torch
-    t1 = torch.as_tensor(np.ascontiguousarray(tset1.reshape(rs1, cp)), device=device)
-    t2 = torch.as_tensor(np.ascontiguousarray(tset2.reshape(rs2, cp)), device=device)
-    enc = _enc_torch([t1, t2], torch)
+    t1 = backend.to_tensor(np.ascontiguousarray(tset1.reshape(rs1, cp)), dtype='int64', device=device)
+    t2 = backend.to_tensor(np.ascontiguousarray(tset2.reshape(rs2, cp)), dtype='int64', device=device)
+    enc = _enc_rows([t1, t2], backend, device)
     if enc is None:
         return find_matching_indices(tset1, tset2, both=both)
     v1, v2 = enc  # v1 ascending: tset1 sorted + order-preserving encoding
-    ind1 = torch.searchsorted(v1, v2)
+    ind1 = backend.searchsorted(v1, v2)
     m = ind1 < rs1
-    safe = torch.where(m, ind1, torch.zeros_like(ind1))
+    safe = backend.where(m, ind1, backend.zeros_like(ind1))
     m = m & (v1[safe] == v2)
-    out1 = ind1[m].cpu().numpy()
+    out1 = backend.to_numpy(ind1[m])
     if both:
-        return out1, torch.nonzero(m, as_tuple=True)[0].cpu().numpy()
+        return out1, backend.to_numpy(backend.nonzero(m)[0])
     return out1
 
 
@@ -312,18 +197,19 @@ def _find_matching_indices_gpu(tset1, tset2, both=True, device=None):
 
 @lru_cache(maxsize=1024)
 @nsys_profile
-def _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, n, mask, taxes_sub, device):
+def _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, n, mask, taxes_sub, device, backend_id):
+    backend = import_backend(backend_id)
     tblocks_full, _ = get_blocks_charges_all(sym, taxes_full, saxes, n)
     if mask.array is not None:
         tblocks_full = tblocks_full[mask.array]
     tblocks_sub, iblocks_sub = get_blocks_charges_all(sym, taxes_sub, saxes, n)
-    inds_sub = _find_matching_indices_gpu(tblocks_sub, tblocks_full, both=False, device=device)
+    inds_sub = _find_matching_indices_gpu(tblocks_sub, tblocks_full, both=False, device=device, backend=backend)
     iblocks_sub = iblocks_sub[inds_sub]
     icharges_sub = [np.unique(iblocks_sub[:, i]).tolist() for i in range(len(taxes_sub))]
     taxes_new = tuple(tuple(tax[i] for i in inds) for tax, inds in zip(taxes_sub, icharges_sub))
 
     if taxes_new != taxes_sub:
-        return _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, n, mask, taxes_new, device)
+        return _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, n, mask, taxes_new, device, backend_id)
 
     if mask.array is not None:
         mask_sub = np.zeros(len(tblocks_sub), dtype=bool)
@@ -335,20 +221,20 @@ def _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, n, mask, taxes_sub, d
 
 
 @nsys_profile
-def _get_trimmed_struct_gpu(sym, struct, sub_legs, device):
+def _get_trimmed_struct_gpu(sym, struct, sub_legs, device, backend_id):
     saxes = tuple(int(leg.s) for leg in struct.legs)
     taxes_full = tuple(tuple(tuple(map(int, tt)) for tt, d in zip(leg.t, leg.D) if d > 0) for leg in struct.legs)
     if sub_legs is None:
         taxes_sub = taxes_full
     else:
         taxes_sub = tuple(tuple(tuple(map(int, tt)) for tt, d in zip(leg.t, leg.D) if d > 0) for leg in sub_legs)
-    taxes_new, mask_sub = _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, struct.n, struct.mask, taxes_sub, device)
+    taxes_new, mask_sub = _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, struct.n, struct.mask, taxes_sub, device, backend_id)
     legs_new = tuple(leg.trim(tax) for leg, tax in zip(struct.legs, taxes_new))
     return _struct(legs=tuple(legs_new), n=struct.n, isdiag=struct.isdiag, mask=mask_sub)
 
 
 @nsys_profile
-def _match_legs_tensordot_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device):
+def _match_legs_tensordot_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device, backend_id):
     assert not struct_a.isdiag, "Sanity check. Contact developers."
     assert not struct_b.isdiag, "Sanity check. Contact developers."
     n_c = sym.add_charges(struct_a.n, struct_b.n)
@@ -364,12 +250,12 @@ def _match_legs_tensordot_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nou
             legs_a_new[ia] = leg
             legs_b_new[ib] = leg.conj()
 
-        struct_a_1 = _get_trimmed_struct_gpu(sym, struct_a_0, legs_a_new, device)
-        struct_b_1 = _get_trimmed_struct_gpu(sym, struct_b_0, legs_b_new, device)
+        struct_a_1 = _get_trimmed_struct_gpu(sym, struct_a_0, legs_a_new, device, backend_id)
+        struct_b_1 = _get_trimmed_struct_gpu(sym, struct_b_0, legs_b_new, device, backend_id)
 
         legs_c = (*(struct_a_1.legs[ax] for ax in nout_a), *(struct_b_1.legs[ax] for ax in nout_b))
         struct_c_0 = _struct(legs=legs_c, n=n_c, isdiag=False)
-        struct_c_1 = _get_trimmed_struct_gpu(sym, struct_c_0, None, device)
+        struct_c_1 = _get_trimmed_struct_gpu(sym, struct_c_0, None, device, backend_id)
 
         if struct_a_0 == struct_a_1 and struct_b_0 == struct_b_1 and struct_c_0 == struct_c_1:
             break
@@ -384,32 +270,34 @@ def _match_legs_tensordot_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nou
     return struct_a_1, struct_b_1, struct_c_1
 
 
-def _get_blocks_and_subslices_gpu(sym, struct_sub, struct_full, device):
+def _get_blocks_and_subslices_gpu(sym, struct_sub, struct_full, device, backend):
     bl = get_blocks(sym, struct_sub)
     if struct_sub == struct_full:
         slc = bl.slc
     else:
         bl_full = get_blocks(sym, struct_full)
-        slc = bl_full.slc[_find_matching_indices_gpu(bl_full.t, bl.t, both=False, device=device)]
+        slc = bl_full.slc[_find_matching_indices_gpu(bl_full.t, bl.t, both=False, device=device, backend=backend)]
     return bl, slc
 
 
 @lru_cache(maxsize=1024)
 @nsys_profile
-def _meta_tensordot_cutensor_v3(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, lazy_threshold, device):
-    if device is None or getattr(device, 'type', None) != 'cuda':  # no GPU -> optimized CPU path
-        return _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+def _meta_tensordot_cutensor_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, 
+                                 lazy_threshold:float=None, device:str=None, backend_id:str=None):
+    if device in [None, ""] or "cpu" in device.lower():
+        raise ValueError("GPU device is required for _meta_tensordot_cutensor_gpu.")
+    backend = import_backend(backend_id)
     struct_a_sub, struct_b_sub, struct_c = \
-        _match_legs_tensordot_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device)
-    bl_a, slc_a = _get_blocks_and_subslices_gpu(sym, struct_a_sub, struct_a, device)
-    bl_b, slc_b = _get_blocks_and_subslices_gpu(sym, struct_b_sub, struct_b, device)
+        _match_legs_tensordot_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device, backend_id)
+    bl_a, slc_a = _get_blocks_and_subslices_gpu(sym, struct_a_sub, struct_a, device, backend)
+    bl_b, slc_b = _get_blocks_and_subslices_gpu(sym, struct_b_sub, struct_b, device, backend)
     bl_c = get_blocks(sym, struct_c)
 
     if lazy_threshold and bl_c.nblocks:
         with nvtx_range("unique out blocks"):
-            mask = _output_mask_gpu(bl_a, bl_b, bl_c, nout_a, nin_a, nin_b, nout_b, device)
+            mask = _output_mask_gpu(bl_a, bl_b, bl_c, nout_a, nin_a, nin_b, nout_b, device, backend)
         if mask is None:  # int64 overflow -> optimized CPU path (rare)
-            return _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+            return None
         struct_c = struct_c.replace(mask=mask)
         bl_c = get_blocks(sym, struct_c)
 

--- a/yastn/tensor/_contractions_cutensor.py
+++ b/yastn/tensor/_contractions_cutensor.py
@@ -284,9 +284,9 @@ def _get_blocks_and_subslices_gpu(sym, struct_sub, struct_full, device, backend)
 @nsys_profile
 def _meta_tensordot_cutensor_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, 
                                  lazy_threshold:float=None, device:str=None, backend_id:str=None):
-    if device in [None, ""] or "cpu" in device.lower():
-        raise ValueError("GPU device is required for _meta_tensordot_cutensor_gpu.")
     backend = import_backend(backend_id)
+    if backend.is_cpu_device(device):
+        raise ValueError("GPU device is required for _meta_tensordot_cutensor_gpu.")
     struct_a_sub, struct_b_sub, struct_c = \
         _match_legs_tensordot_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device, backend_id)
     bl_a, slc_a = _get_blocks_and_subslices_gpu(sym, struct_a_sub, struct_a, device, backend)

--- a/yastn/tensor/_contractions_cutensor.py
+++ b/yastn/tensor/_contractions_cutensor.py
@@ -25,14 +25,21 @@ there selects between them. The int64 row encoder (:func:`_encode_rows_shared` /
 """
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 
 import numpy as np
 
 from .._profile import nsys_profile, nvtx_range
-from ._auxiliary import _encode_rows_shared, _row_keys_pair, get_blocks, hash_blocks
-from ._contractions import (_convert_bl_for_cutensor, _cutensor_meta, _match_legs_tensordot, 
+from ._auxiliary import (_encode_rows_shared, _row_keys_pair, get_blocks, hash_blocks,
+                         _struct, HashedMask, get_blocks_charges_all, find_matching_indices)
+from ._contractions import (_convert_bl_for_cutensor, _cutensor_meta, _match_legs_tensordot,
                             get_blocks_and_subslices, _matched_pair_indices,)
+from ._tests import YastnError
+
+#: Below this many rows the GPU (v3) matcher / mask fall back to numpy (launch+transfer
+#: overhead dominates). Tunable via env ``YASTN_META_CUTENSOR_GPU_MIN``.
+_GPU_MIN = int(os.environ.get("YASTN_META_CUTENSOR_GPU_MIN", "4096"))
 
 
 @nsys_profile
@@ -126,6 +133,284 @@ def _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, n
         struct_c = struct_c.replace(mask=mask)
         bl_c = get_blocks(sym, struct_c)
     
+    # dot product, which cannot be simply dispatched to vdot
+    #              and either one of operands is (effectively) zero
+    if not (len(slc_a) > 0 and len(slc_b) > 0):
+        return struct_c, 0, *([None] * 18)
+    else:
+        dot_product = len(nout_a) + len(nout_b) == 0
+        a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets = \
+            _convert_bl_for_cutensor(struct_a_sub, bl_a, slc_a, dot_product=(dot_product and len(slc_a) < len(slc_b)))
+        b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets = \
+            _convert_bl_for_cutensor(struct_b_sub, bl_b, slc_b, dot_product=(dot_product and len(slc_a) >= len(slc_b)))
+        c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets = \
+            _convert_bl_for_cutensor(struct_c, bl_c, dot_product=dot_product)
+
+        h_a, h_b, h_c = hash_blocks(_cutensor_meta(a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides), out=bytes),\
+                    hash_blocks(_cutensor_meta(b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides), out=bytes),\
+                    hash_blocks(_cutensor_meta(c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides), out=bytes)
+
+    return (struct_c, bl_c.size, h_a, h_b, h_c,
+            a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets,
+            b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets,
+            c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets)
+
+
+# =====================================================================================
+# GPU (v3) path. torch is imported lazily *inside* functions so that ``import yastn`` and
+# ``_control_lru`` (which imports this module) never pull torch for numpy-only users.
+# The shared find_matching_indices and trimming stay untouched; v3 uses its own GPU copies.
+# =====================================================================================
+
+
+def _enc_torch(tsets, torch):
+    """
+    torch twin of :func:`_encode_rows_shared`: order-preserving int64 mixed-radix keys per row
+    of each 2-D tensor in ``tsets`` (shared per-column value set), or ``None`` on int64 overflow.
+    """
+    cp = tsets[0].shape[1]
+    sizes = [t.shape[0] for t in tsets]
+    dev = tsets[0].device
+    if cp == 0:
+        keys = torch.zeros(sum(sizes), dtype=torch.int64, device=dev)
+    else:
+        stacked = torch.cat(tsets, 0) if len(tsets) > 1 else tsets[0]
+        invs, radices, prod = [], [], 1
+        for j in range(cp):
+            u, inv = torch.unique(stacked[:, j], return_inverse=True)
+            invs.append(inv.reshape(-1)); radices.append(u.numel()); prod *= u.numel()
+            if prod >= (1 << 62):
+                return None
+        keys = torch.zeros(sum(sizes), dtype=torch.int64, device=dev)
+        w = 1
+        for j in range(cp - 1, -1, -1):  # column 0 most significant (matches np.unique(axis=0))
+            keys += invs[j].to(torch.int64) * w
+            w *= radices[j]
+    out, off = [], 0
+    for s in sizes:
+        out.append(keys[off: off + s]); off += s
+    return out
+
+
+def _locate_torch(sorted_u, q, torch):
+    """ torch twin of :func:`locate_rows` on 1-D keys: index of each ``q`` in ``sorted_u`` or
+    the sentinel ``len(sorted_u)`` when absent. """
+    n = sorted_u.numel()
+    if n == 0:
+        return torch.zeros(q.numel(), dtype=torch.int64, device=q.device)  # sentinel 0 == n
+    ids = torch.searchsorted(sorted_u, q)
+    hit = ids < n
+    safe = torch.where(hit, ids, torch.zeros_like(ids))
+    hit = hit & (sorted_u[safe] == q)
+    ids = ids.clone()
+    ids[~hit] = n
+    return ids
+
+
+def _matched_pairs_torch(sa, sb, torch):
+    """
+    Block-index lists ``(ind_a, ind_b)`` of every matching (a, b) pair, given the shared-space
+    contracted-sector key of each a-/b-block. torch twin of ``_indices_from_counts`` + the
+    ``arg_*`` gather: sort by sector, count per sector, union-align, then a segmented cartesian
+    product. Pair order is irrelevant downstream (only the set of produced keys is used).
+    """
+    dev = sa.device
+    ord_a = torch.argsort(sa); ord_b = torch.argsort(sb)
+    ua, ca = torch.unique_consecutive(sa[ord_a], return_counts=True)
+    ub, cb = torch.unique_consecutive(sb[ord_b], return_counts=True)
+    starts_a = torch.cumsum(ca, 0) - ca
+    starts_b = torch.cumsum(cb, 0) - cb
+    uni = torch.unique(torch.cat([ua, ub]))
+    pa = torch.searchsorted(uni, ua); pb = torch.searchsorted(uni, ub)
+    ca2 = torch.zeros(uni.numel(), dtype=torch.int64, device=dev); ca2[pa] = ca
+    cb2 = torch.zeros_like(ca2); cb2[pb] = cb
+    sa2 = torch.zeros_like(ca2); sa2[pa] = starts_a
+    sb2 = torch.zeros_like(ca2); sb2[pb] = starts_b
+    prod = ca2 * cb2
+    nn = int(prod.sum().item())
+    if nn == 0:
+        empty = torch.empty(0, dtype=torch.int64, device=dev)
+        return empty, empty
+    seg = torch.repeat_interleave(torch.arange(uni.numel(), device=dev), prod)
+    within = torch.arange(nn, device=dev) - (torch.cumsum(prod, 0) - prod)[seg]
+    cbseg = cb2[seg]
+    ind_a = ord_a[sa2[seg] + within // cbseg]
+    ind_b = ord_b[sb2[seg] + within % cbseg]
+    return ind_a, ind_b
+
+
+def _output_mask_gpu(bl_a, bl_b, bl_c, nout_a, nin_a, nin_b, nout_b, device):
+    """
+    GPU twin of v2's mask-c step: boolean mask (numpy) over ``bl_c`` blocks that are actually
+    produced. Only ``bl_*.t`` cross to the device (nn stays on GPU); returns ``None`` on int64
+    overflow so the caller can fall back to numpy.
+    """
+    import torch
+    nba, nbb, nbc = bl_a.nblocks, bl_b.nblocks, bl_c.nblocks
+    na, nb = len(nout_a), len(nout_b)
+    nsym = bl_a.t.shape[2]
+    ta = torch.as_tensor(bl_a.t, device=device)
+    tb = torch.as_tensor(bl_b.t, device=device)
+    tc = torch.as_tensor(bl_c.t, device=device)
+    # contracted-sector keys (shared a/b) -> matched (a, b) pairs
+    enc = _enc_torch([ta[:, nin_a, :].reshape(nba, len(nin_a) * nsym),
+                      tb[:, nin_b, :].reshape(nbb, len(nin_b) * nsym)], torch)
+    if enc is None:
+        return None
+    ind_a, ind_b = _matched_pairs_torch(enc[0], enc[1], torch)
+    # out-charge ids: a-out shared with bl_c[:na], b-out shared with bl_c[na:]
+    enca = _enc_torch([ta[:, nout_a, :].reshape(nba, na * nsym),
+                       tc[:, :na, :].reshape(nbc, na * nsym)], torch)
+    encb = _enc_torch([tb[:, nout_b, :].reshape(nbb, nb * nsym),
+                       tc[:, na:, :].reshape(nbc, nb * nsym)], torch)
+    if enca is None or encb is None:
+        return None
+    ua_keys, id_a = torch.unique(enca[0], return_inverse=True)
+    ub_keys, id_b = torch.unique(encb[0], return_inverse=True)
+    cid_a = _locate_torch(ua_keys, enca[1], torch)
+    cid_b = _locate_torch(ub_keys, encb[1], torch)
+    n_b = ub_keys.numel()
+    keys = torch.unique(id_a.reshape(-1)[ind_a] * n_b + id_b.reshape(-1)[ind_b])
+    valid = (cid_a < ua_keys.numel()) & (cid_b < n_b)
+    c_keys = torch.where(valid, cid_a * n_b + cid_b, torch.full_like(cid_a, -1))
+    return torch.isin(c_keys, keys).cpu().numpy()
+
+
+def _find_matching_indices_gpu(tset1, tset2, both=True, device=None):
+    """
+    GPU-accelerated drop-in for :func:`find_matching_indices` (numpy in / numpy out), used only
+    by the v3-local trimming copies. Falls back to the untouched numpy ``find_matching_indices``
+    for cpu device, small inputs, or int64 overflow. ``tset1`` must be sorted-unique (as the
+    numpy version already requires).
+    """
+    rs1, *cs1 = tset1.shape
+    rs2, *cs2 = tset2.shape
+    cp = int(np.prod(cs1, dtype=np.int64))
+    if (device is None or getattr(device, 'type', None) != 'cuda'
+            or cp == 0 or rs1 == 0 or rs2 == 0 or max(rs1, rs2) < _GPU_MIN):
+        return find_matching_indices(tset1, tset2, both=both)
+    import torch
+    t1 = torch.as_tensor(np.ascontiguousarray(tset1.reshape(rs1, cp)), device=device)
+    t2 = torch.as_tensor(np.ascontiguousarray(tset2.reshape(rs2, cp)), device=device)
+    enc = _enc_torch([t1, t2], torch)
+    if enc is None:
+        return find_matching_indices(tset1, tset2, both=both)
+    v1, v2 = enc  # v1 ascending: tset1 sorted + order-preserving encoding
+    ind1 = torch.searchsorted(v1, v2)
+    m = ind1 < rs1
+    safe = torch.where(m, ind1, torch.zeros_like(ind1))
+    m = m & (v1[safe] == v2)
+    out1 = ind1[m].cpu().numpy()
+    if both:
+        return out1, torch.nonzero(m, as_tuple=True)[0].cpu().numpy()
+    return out1
+
+
+# --- v3-local copies of the trimming path (shared versions in _contractions / _auxiliary are
+# --- left untouched); the only change is find_matching_indices -> _find_matching_indices_gpu.
+
+@lru_cache(maxsize=1024)
+@nsys_profile
+def _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, n, mask, taxes_sub, device):
+    tblocks_full, _ = get_blocks_charges_all(sym, taxes_full, saxes, n)
+    if mask.array is not None:
+        tblocks_full = tblocks_full[mask.array]
+    tblocks_sub, iblocks_sub = get_blocks_charges_all(sym, taxes_sub, saxes, n)
+    inds_sub = _find_matching_indices_gpu(tblocks_sub, tblocks_full, both=False, device=device)
+    iblocks_sub = iblocks_sub[inds_sub]
+    icharges_sub = [np.unique(iblocks_sub[:, i]).tolist() for i in range(len(taxes_sub))]
+    taxes_new = tuple(tuple(tax[i] for i in inds) for tax, inds in zip(taxes_sub, icharges_sub))
+
+    if taxes_new != taxes_sub:
+        return _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, n, mask, taxes_new, device)
+
+    if mask.array is not None:
+        mask_sub = np.zeros(len(tblocks_sub), dtype=bool)
+        mask_sub[inds_sub] = True
+        mask_sub = HashedMask(mask_sub)
+    else:
+        mask_sub = mask
+    return taxes_new, mask_sub
+
+
+@nsys_profile
+def _get_trimmed_struct_gpu(sym, struct, sub_legs, device):
+    saxes = tuple(int(leg.s) for leg in struct.legs)
+    taxes_full = tuple(tuple(tuple(map(int, tt)) for tt, d in zip(leg.t, leg.D) if d > 0) for leg in struct.legs)
+    if sub_legs is None:
+        taxes_sub = taxes_full
+    else:
+        taxes_sub = tuple(tuple(tuple(map(int, tt)) for tt, d in zip(leg.t, leg.D) if d > 0) for leg in sub_legs)
+    taxes_new, mask_sub = _get_trimmed_struct_engine_gpu(sym, taxes_full, saxes, struct.n, struct.mask, taxes_sub, device)
+    legs_new = tuple(leg.trim(tax) for leg, tax in zip(struct.legs, taxes_new))
+    return _struct(legs=tuple(legs_new), n=struct.n, isdiag=struct.isdiag, mask=mask_sub)
+
+
+@nsys_profile
+def _match_legs_tensordot_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device):
+    assert not struct_a.isdiag, "Sanity check. Contact developers."
+    assert not struct_b.isdiag, "Sanity check. Contact developers."
+    n_c = sym.add_charges(struct_a.n, struct_b.n)
+    #
+    struct_a_0, struct_b_0 = struct_a, struct_b
+    legs_a_new, legs_b_new = list(struct_a.legs), list(struct_b.legs)
+    while True:
+        for ia, ib in zip(nin_a, nin_b):
+            try:
+                leg = struct_a_0.legs[ia].intersection(struct_b_0.legs[ib].conj())
+            except ValueError:
+                raise YastnError('Bond dimensions of some charges do not match.')
+            legs_a_new[ia] = leg
+            legs_b_new[ib] = leg.conj()
+
+        struct_a_1 = _get_trimmed_struct_gpu(sym, struct_a_0, legs_a_new, device)
+        struct_b_1 = _get_trimmed_struct_gpu(sym, struct_b_0, legs_b_new, device)
+
+        legs_c = (*(struct_a_1.legs[ax] for ax in nout_a), *(struct_b_1.legs[ax] for ax in nout_b))
+        struct_c_0 = _struct(legs=legs_c, n=n_c, isdiag=False)
+        struct_c_1 = _get_trimmed_struct_gpu(sym, struct_c_0, None, device)
+
+        if struct_a_0 == struct_a_1 and struct_b_0 == struct_b_1 and struct_c_0 == struct_c_1:
+            break
+
+        struct_a_0 = struct_a_1
+        struct_b_0 = struct_b_1
+        for ii, ax in enumerate(nout_a):
+            legs_a_new[ax] = struct_c_1.legs[ii].intersection(struct_a_1.legs[ax])
+        for ii, ax in enumerate(nout_b, start=len(nout_a)):
+            legs_b_new[ax] = struct_c_1.legs[ii].intersection(struct_b_1.legs[ax])
+
+    return struct_a_1, struct_b_1, struct_c_1
+
+
+def _get_blocks_and_subslices_gpu(sym, struct_sub, struct_full, device):
+    bl = get_blocks(sym, struct_sub)
+    if struct_sub == struct_full:
+        slc = bl.slc
+    else:
+        bl_full = get_blocks(sym, struct_full)
+        slc = bl_full.slc[_find_matching_indices_gpu(bl_full.t, bl.t, both=False, device=device)]
+    return bl, slc
+
+
+@lru_cache(maxsize=1024)
+@nsys_profile
+def _meta_tensordot_cutensor_v3(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device):
+    if device is None or getattr(device, 'type', None) != 'cuda':  # no GPU -> optimized CPU path
+        return _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+    struct_a_sub, struct_b_sub, struct_c = \
+        _match_legs_tensordot_gpu(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b, device)
+    bl_a, slc_a = _get_blocks_and_subslices_gpu(sym, struct_a_sub, struct_a, device)
+    bl_b, slc_b = _get_blocks_and_subslices_gpu(sym, struct_b_sub, struct_b, device)
+    bl_c = get_blocks(sym, struct_c)
+
+    with nvtx_range("unique out blocks"):
+        mask = _output_mask_gpu(bl_a, bl_b, bl_c, nout_a, nin_a, nin_b, nout_b, device)
+    if mask is None:  # int64 overflow -> optimized CPU path (rare)
+        return _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+    struct_c = struct_c.replace(mask=mask)
+    bl_c = get_blocks(sym, struct_c)
+
     # dot product, which cannot be simply dispatched to vdot
     #              and either one of operands is (effectively) zero
     if not (len(slc_a) > 0 and len(slc_b) > 0):

--- a/yastn/tensor/_contractions_cutensor.py
+++ b/yastn/tensor/_contractions_cutensor.py
@@ -1,0 +1,149 @@
+# Copyright 2026 The YASTN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+Optimized (v2) builder of the cutensor tensordot meta.
+
+This module isolates the accelerated variant of ``_meta_tensordot_cutensor`` and the row
+helpers it relies on. The original reference variant (v1) lives in :mod:`._contractions`,
+together with the pieces both variants share (leg matching ``_match_legs_tensordot`` and the
+pair-index alignment ``_matched_pair_indices``); the A/B toggle ``_META_CUTENSOR_VERSION``
+there selects between them. The int64 row encoder (:func:`_encode_rows_shared` /
+:func:`_row_keys_pair`) stays in :mod:`._auxiliary`, where it also backs
+:func:`find_matching_indices`.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+
+import numpy as np
+
+from .._profile import nsys_profile, nvtx_range
+from ._auxiliary import _encode_rows_shared, _row_keys_pair, get_blocks, hash_blocks
+from ._contractions import (_convert_bl_for_cutensor, _cutensor_meta, _match_legs_tensordot, 
+                            get_blocks_and_subslices, _matched_pair_indices,)
+
+
+@nsys_profile
+def locate_rows(tset, query):
+    """
+    Index of each row of ``query`` within ``tset``, or ``len(tset)`` when the row is absent.
+
+    ``tset`` must have unique rows sorted in the same (per-column, lexicographic) order
+    produced by ``np.unique(..., axis=0)``; ``query`` may contain arbitrary/repeated rows.
+    Unlike :func:`yastn.tensor._auxiliary.find_matching_indices`, the result has one entry
+    per row of ``query`` (misses flagged with the sentinel ``len(tset)``), so it maps rows
+    to their class id.
+    """
+    rs, *cs = tset.shape
+    rq, *cq = query.shape
+    assert cs == cq, "Sanity check. Contact developers."
+    cp = np.prod(cs, dtype=np.int64)
+    if rs == 0:  # empty tset: every query row is absent
+        return np.full(rq, rs, dtype=np.int64)
+    if cp == 0:  # zero-width rows collapse to a single (empty) class present in tset
+        return np.zeros(rq, dtype=np.int64)
+    v_t, v_q = _row_keys_pair(tset.reshape(rs, cp), query.reshape(rq, cp))
+    ids = np.searchsorted(v_t, v_q)
+    hit = ids < rs
+    safe_ind = np.where(hit, ids, 0)
+    hit &= v_t[safe_ind] == v_q
+    ids[~hit] = rs  # sentinel for rows absent from tset
+    return ids
+
+
+def unique_rows(t, return_inverse=False, return_counts=False):
+    """
+    Drop-in accelerator for ``np.unique(t, axis=0, ...)`` on integer charge blocks.
+
+    Encodes rows as order-preserving int64 keys and uniques those in 1-D, which is markedly
+    faster than numpy's structured/void ``axis=0`` sort; falls back to ``np.unique(axis=0)``
+    when the key space would overflow. Returns rows in the same order as ``np.unique(axis=0)``
+    and preserves the input's row shape ``t.shape[1:]``.
+    """
+    rs = t.shape[0]
+    cp = int(np.prod(t.shape[1:], dtype=np.int64))
+    enc = _encode_rows_shared([t.reshape(rs, cp)]) if rs > 0 else None
+    if enc is None:
+        return np.unique(t, axis=0, return_inverse=return_inverse, return_counts=return_counts)
+    uk, first, inv, cnt = np.unique(enc[0], return_index=True, return_inverse=True, return_counts=True)
+    res = [t[first]]  # representative row per class, in key-sorted (== structured-sorted) order
+    if return_inverse:
+        res.append(inv.reshape(-1))
+    if return_counts:
+        res.append(cnt)
+    return res[0] if len(res) == 1 else tuple(res)
+
+
+@lru_cache(maxsize=1024)
+@nsys_profile
+def _meta_tensordot_cutensor_v2(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b):
+    struct_a_sub, struct_b_sub, struct_c = _match_legs_tensordot(sym, struct_a, struct_b, nout_a, nin_a, nin_b, nout_b)
+    bl_a, slc_a = get_blocks_and_subslices(sym, struct_a_sub, struct_a)
+    bl_b, slc_b = get_blocks_and_subslices(sym, struct_b_sub, struct_b)
+    bl_c = get_blocks(sym, struct_c)
+    
+    with nvtx_range("unique in blocks"):
+        unique_a, inv_a, count_a = unique_rows(bl_a.t[:, nin_a, :], return_inverse=True, return_counts=True) # if more blocks of a contribute to given contracted sector (in b)
+        arg_a = np.argsort(inv_a)
+        #
+        unique_b, inv_b, count_b = unique_rows(bl_b.t[:, nin_b, :], return_inverse=True, return_counts=True)
+        arg_b = np.argsort(inv_b)
+    #
+    ind_a, ind_b = _matched_pair_indices(unique_a, count_a, arg_a, unique_b, count_b, arg_b)
+    #
+    with nvtx_range("unique out blocks"):
+        # A candidate output block of bl_c is produced iff its (out_a, out_b) charge tuple
+        # arises from some matched (a, b) pair. Encode each out_a / out_b tuple as a small
+        # integer id (one class per distinct tuple among the blocks) and reduce the per-pair
+        # test to 1-D int64 operations. This avoids building and sorting the ~nn wide rows
+        # that column_stack + np.unique(axis=0) would otherwise require (nn = matched pairs).
+        na, nb, nsym = len(nout_a), len(nout_b), bl_a.t.shape[2]  # explicit widths: bl_*.nblocks may be 0
+        ua, id_a = unique_rows(bl_a.t[:, nout_a, :].reshape(bl_a.nblocks, na * nsym), return_inverse=True)
+        ub, id_b = unique_rows(bl_b.t[:, nout_b, :].reshape(bl_b.nblocks, nb * nsym), return_inverse=True)
+        id_a, id_b, n_b = id_a.reshape(-1), id_b.reshape(-1), len(ub)
+        #
+        keys = np.unique(id_a[ind_a] * n_b + id_b[ind_b])  # produced (out_a, out_b) classes
+        #
+        # struct_c legs are ordered (out_a from nout_a, then out_b from nout_b), so bl_c.t
+        # splits into its out_a (:na) and out_b (na:) columns aligned with ua / ub above
+        cid_a = locate_rows(ua, bl_c.t[:, :na, :].reshape(bl_c.nblocks, na * nsym))
+        cid_b = locate_rows(ub, bl_c.t[:, na:, :].reshape(bl_c.nblocks, nb * nsym))
+        c_keys = np.where((cid_a < len(ua)) & (cid_b < n_b), cid_a * n_b + cid_b, -1)
+        #
+        mask = np.isin(c_keys, keys)  # -1 sentinel (tuple absent from a/b blocks) never matches
+        struct_c = struct_c.replace(mask=mask)
+        bl_c = get_blocks(sym, struct_c)
+    
+    # dot product, which cannot be simply dispatched to vdot
+    #              and either one of operands is (effectively) zero
+    if not (len(slc_a) > 0 and len(slc_b) > 0):
+        return struct_c, 0, *([None] * 18)
+    else:
+        dot_product = len(nout_a) + len(nout_b) == 0
+        a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets = \
+            _convert_bl_for_cutensor(struct_a_sub, bl_a, slc_a, dot_product=(dot_product and len(slc_a) < len(slc_b)))
+        b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets = \
+            _convert_bl_for_cutensor(struct_b_sub, bl_b, slc_b, dot_product=(dot_product and len(slc_a) >= len(slc_b)))
+        c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets = \
+            _convert_bl_for_cutensor(struct_c, bl_c, dot_product=dot_product)
+
+        h_a, h_b, h_c = hash_blocks(_cutensor_meta(a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides), out=bytes),\
+                    hash_blocks(_cutensor_meta(b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides), out=bytes),\
+                    hash_blocks(_cutensor_meta(c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides), out=bytes)
+
+    return (struct_c, bl_c.size, h_a, h_b, h_c,
+            a_numSectionsPerMode, a_sectionExtents, a_coords, a_strides, a_offsets,
+            b_numSectionsPerMode, b_sectionExtents, b_coords, b_strides, b_offsets,
+            c_numSectionsPerMode, c_sectionExtents, c_coords, c_strides, c_offsets)

--- a/yastn/tensor/_control_lru.py
+++ b/yastn/tensor/_control_lru.py
@@ -26,9 +26,8 @@ def set_cache_maxsize(maxsize=0):
     _contractions._meta_tensordot_f2m = lru_cache(maxsize)(_contractions._meta_tensordot_f2m.__wrapped__)
     _contractions._meta_tensordot_fc = lru_cache(maxsize)(_contractions._meta_tensordot_fc.__wrapped__)
     _contractions._meta_tensordot_nf = lru_cache(maxsize)(_contractions._meta_tensordot_nf.__wrapped__)
-    _contractions._meta_tensordot_cutensor_v1 = lru_cache(maxsize)(_contractions._meta_tensordot_cutensor_v1.__wrapped__)
-    _contractions_cutensor._meta_tensordot_cutensor_v2 = lru_cache(maxsize)(_contractions_cutensor._meta_tensordot_cutensor_v2.__wrapped__)
-    _contractions_cutensor._meta_tensordot_cutensor_v3 = lru_cache(maxsize)(_contractions_cutensor._meta_tensordot_cutensor_v3.__wrapped__)
+    _contractions._meta_tensordot_cutensor_cpu = lru_cache(maxsize)(_contractions._meta_tensordot_cutensor_cpu.__wrapped__)
+    _contractions_cutensor._meta_tensordot_cutensor_gpu = lru_cache(maxsize)(_contractions_cutensor._meta_tensordot_cutensor_gpu.__wrapped__)
     _contractions_cutensor._get_trimmed_struct_engine_gpu = lru_cache(maxsize)(_contractions_cutensor._get_trimmed_struct_engine_gpu.__wrapped__)
     _contractions._meta_mask = lru_cache(maxsize)(_contractions._meta_mask.__wrapped__)
     _contractions._meta_swap_gate = lru_cache(maxsize)(_contractions._meta_swap_gate.__wrapped__)
@@ -52,9 +51,8 @@ def clear_cache():
     _contractions._meta_tensordot_f2m.cache_clear()
     _contractions._meta_tensordot_fc.cache_clear()
     _contractions._meta_tensordot_nf.cache_clear()
-    _contractions._meta_tensordot_cutensor_v1.cache_clear()
-    _contractions_cutensor._meta_tensordot_cutensor_v2.cache_clear()
-    _contractions_cutensor._meta_tensordot_cutensor_v3.cache_clear()
+    _contractions._meta_tensordot_cutensor_cpu.cache_clear()
+    _contractions_cutensor._meta_tensordot_cutensor_gpu.cache_clear()
     _contractions_cutensor._get_trimmed_struct_engine_gpu.cache_clear()
     _contractions._meta_mask.cache_clear()
     _contractions._meta_swap_gate.cache_clear()
@@ -81,9 +79,8 @@ def get_cache_info():
             "tensordot_f2m": _contractions._meta_tensordot_f2m.cache_info(),
             "tensordot_fc": _contractions._meta_tensordot_fc.cache_info(),
             "tensordot_nf": _contractions._meta_tensordot_nf.cache_info(),
-            "tensordot_cutensor_v1": _contractions._meta_tensordot_cutensor_v1.cache_info(),
-            "tensordot_cutensor_v2": _contractions_cutensor._meta_tensordot_cutensor_v2.cache_info(),
-            "tensordot_cutensor_v3": _contractions_cutensor._meta_tensordot_cutensor_v3.cache_info(),
+            "tensordot_cutensor_cpu": _contractions._meta_tensordot_cutensor_cpu.cache_info(),
+            "tensordot_cutensor_gpu": _contractions_cutensor._meta_tensordot_cutensor_gpu.cache_info(),
             "get_trimmed_struct_engine_gpu": _contractions_cutensor._get_trimmed_struct_engine_gpu.cache_info(),
             "broadcast": _contractions._meta_broadcast.cache_info(),
             "mask": _contractions._meta_mask.cache_info(),

--- a/yastn/tensor/_control_lru.py
+++ b/yastn/tensor/_control_lru.py
@@ -15,7 +15,7 @@
 """ Dynamical changing of lru_cache maxsize. """
 from functools import lru_cache
 
-from . import _algebra, _merging, _contractions, _einsum, _auxiliary
+from . import _algebra, _merging, _contractions, _contractions_cutensor, _einsum, _auxiliary
 
 __all__ = ['clear_cache', 'get_cache_info', 'set_cache_maxsize']
 
@@ -26,7 +26,8 @@ def set_cache_maxsize(maxsize=0):
     _contractions._meta_tensordot_f2m = lru_cache(maxsize)(_contractions._meta_tensordot_f2m.__wrapped__)
     _contractions._meta_tensordot_fc = lru_cache(maxsize)(_contractions._meta_tensordot_fc.__wrapped__)
     _contractions._meta_tensordot_nf = lru_cache(maxsize)(_contractions._meta_tensordot_nf.__wrapped__)
-    _contractions._meta_tensordot_cutensor = lru_cache(maxsize)(_contractions._meta_tensordot_cutensor.__wrapped__)
+    _contractions._meta_tensordot_cutensor_v1 = lru_cache(maxsize)(_contractions._meta_tensordot_cutensor_v1.__wrapped__)
+    _contractions_cutensor._meta_tensordot_cutensor_v2 = lru_cache(maxsize)(_contractions_cutensor._meta_tensordot_cutensor_v2.__wrapped__)
     _contractions._meta_mask = lru_cache(maxsize)(_contractions._meta_mask.__wrapped__)
     _contractions._meta_swap_gate = lru_cache(maxsize)(_contractions._meta_swap_gate.__wrapped__)
     _contractions._meta_swap_gate_charge = lru_cache(maxsize)(_contractions._meta_swap_gate_charge.__wrapped__)
@@ -49,7 +50,8 @@ def clear_cache():
     _contractions._meta_tensordot_f2m.cache_clear()
     _contractions._meta_tensordot_fc.cache_clear()
     _contractions._meta_tensordot_nf.cache_clear()
-    _contractions._meta_tensordot_cutensor.cache_clear()
+    _contractions._meta_tensordot_cutensor_v1.cache_clear()
+    _contractions_cutensor._meta_tensordot_cutensor_v2.cache_clear()
     _contractions._meta_mask.cache_clear()
     _contractions._meta_swap_gate.cache_clear()
     _contractions._meta_swap_gate_charge.cache_clear()
@@ -75,7 +77,8 @@ def get_cache_info():
             "tensordot_f2m": _contractions._meta_tensordot_f2m.cache_info(),
             "tensordot_fc": _contractions._meta_tensordot_fc.cache_info(),
             "tensordot_nf": _contractions._meta_tensordot_nf.cache_info(),
-            "tensordot_cutensor": _contractions._meta_tensordot_cutensor.cache_info(),
+            "tensordot_cutensor_v1": _contractions._meta_tensordot_cutensor_v1.cache_info(),
+            "tensordot_cutensor_v2": _contractions_cutensor._meta_tensordot_cutensor_v2.cache_info(),
             "broadcast": _contractions._meta_broadcast.cache_info(),
             "mask": _contractions._meta_mask.cache_info(),
             "trace": _contractions._meta_trace.cache_info(),

--- a/yastn/tensor/_control_lru.py
+++ b/yastn/tensor/_control_lru.py
@@ -28,6 +28,8 @@ def set_cache_maxsize(maxsize=0):
     _contractions._meta_tensordot_nf = lru_cache(maxsize)(_contractions._meta_tensordot_nf.__wrapped__)
     _contractions._meta_tensordot_cutensor_v1 = lru_cache(maxsize)(_contractions._meta_tensordot_cutensor_v1.__wrapped__)
     _contractions_cutensor._meta_tensordot_cutensor_v2 = lru_cache(maxsize)(_contractions_cutensor._meta_tensordot_cutensor_v2.__wrapped__)
+    _contractions_cutensor._meta_tensordot_cutensor_v3 = lru_cache(maxsize)(_contractions_cutensor._meta_tensordot_cutensor_v3.__wrapped__)
+    _contractions_cutensor._get_trimmed_struct_engine_gpu = lru_cache(maxsize)(_contractions_cutensor._get_trimmed_struct_engine_gpu.__wrapped__)
     _contractions._meta_mask = lru_cache(maxsize)(_contractions._meta_mask.__wrapped__)
     _contractions._meta_swap_gate = lru_cache(maxsize)(_contractions._meta_swap_gate.__wrapped__)
     _contractions._meta_swap_gate_charge = lru_cache(maxsize)(_contractions._meta_swap_gate_charge.__wrapped__)
@@ -52,6 +54,8 @@ def clear_cache():
     _contractions._meta_tensordot_nf.cache_clear()
     _contractions._meta_tensordot_cutensor_v1.cache_clear()
     _contractions_cutensor._meta_tensordot_cutensor_v2.cache_clear()
+    _contractions_cutensor._meta_tensordot_cutensor_v3.cache_clear()
+    _contractions_cutensor._get_trimmed_struct_engine_gpu.cache_clear()
     _contractions._meta_mask.cache_clear()
     _contractions._meta_swap_gate.cache_clear()
     _contractions._meta_swap_gate_charge.cache_clear()
@@ -79,6 +83,8 @@ def get_cache_info():
             "tensordot_nf": _contractions._meta_tensordot_nf.cache_info(),
             "tensordot_cutensor_v1": _contractions._meta_tensordot_cutensor_v1.cache_info(),
             "tensordot_cutensor_v2": _contractions_cutensor._meta_tensordot_cutensor_v2.cache_info(),
+            "tensordot_cutensor_v3": _contractions_cutensor._meta_tensordot_cutensor_v3.cache_info(),
+            "get_trimmed_struct_engine_gpu": _contractions_cutensor._get_trimmed_struct_engine_gpu.cache_info(),
             "broadcast": _contractions._meta_broadcast.cache_info(),
             "mask": _contractions._meta_mask.cache_info(),
             "trace": _contractions._meta_trace.cache_info(),

--- a/yastn/tensor/_initialize.py
+++ b/yastn/tensor/_initialize.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from ._auxiliary import _config, get_blocks, get_trimmed_struct, find_index, find_matching_indices
 from ._tests import YastnError
-from ..backend import backend_np
+from ..backend import backend_np, import_backend
 from ..sym import sym_none, sym_U1, sym_Z2, sym_Z3, sym_U1xU1, sym_U1xU1xZ2
 
 __all__ = ['make_config']
@@ -92,6 +92,22 @@ def make_config(**kwargs) -> _config:
             * ``'fuse_contracted'`` Tensordot involves suitable permutation of each tensor while performing a fusion of to-be-contracted legs of each tensor and calling multiplication. It involves a larger number of multiplication calls for smaller objects, but unfusing the legs of the result is not needed.
             * ``'no_fusion'`` Tensordot involves suitable permutation of tensor blocks and calling matrix-matrix multiplication for a potentially large number of small objects. Resulting contributions to new blocks get added. However, overheads of initial fusion (copying data) can sometimes be avoided in this approach.
 
+    lazy_threshold: float = 0 if backend is cuTensor, else 0.5
+        Not all symmetry-allowed blocks need to be present in "lazy" tensor. Hence, when computing a contractions with "lazy" tensors, 
+        not all blocks allowed by the symmetry need to exist in the resulting tensor. 
+        If the fraction (retained blocks / all allowed blocks)  > ``lazy_threshold``, then blocks are initialized lazily, 
+        i.e., only when they are needed. On ``cuTensor`` backend, defaults to 0, otherwise 0.5
+        Impact:
+            Decreases memory usage and flop count in contractions. The block-sparsity algebra is more expensive.
+        Revelant scenarious:
+            Outer-product-like contractions, where number of legs of resulting tensor is larger than the number of legs of the input tensors. 
+            In such cases, the number of allowed blocks can be much larger than the number of retained blocks.
+
+    meta_tensordot_policy: str = "cpu"|"gpu"|"auto"
+        Block-sparsity algorithm used by :meth:`yastn.tensordot`. The default is ``'auto'``,
+        which uses the optimized GPU algorithm if available, otherwise the CPU algorithm.
+        When "auto" can be also overriden by setting the environment variable ``YASTN_META_CUTENSOR`` to ``"GPU"`` or ``"CPU"``.
+
     Example
     -------
 
@@ -99,16 +115,13 @@ def make_config(**kwargs) -> _config:
 
         config = yastn.make_config(backend='np', sym='U1')
     """
-    if "backend" not in kwargs or kwargs["backend"] == 'np':
+    if "backend" not in kwargs:
         kwargs["backend"] = backend_np
-    elif kwargs["backend"] == 'torch':
-        from ..backend import backend_torch
-        kwargs["backend"] = backend_torch
-    elif kwargs["backend"] == 'torch_cutensor':
-        from ..backend import backend_torch_cutensor  # pragma: no cover
-        kwargs["backend"] = backend_torch_cutensor  # pragma: no cover
     elif isinstance(kwargs["backend"], str):
-        raise YastnError("backend encoded as string only supports: 'np', 'torch'")
+        try:
+            kwargs["backend"] = import_backend(kwargs["backend"])
+        except ValueError:
+            raise YastnError("backend encoded as string only supports: 'np', 'torch'")
 
     if "sym" not in kwargs:
         kwargs["sym"] = sym_none
@@ -117,6 +130,12 @@ def make_config(**kwargs) -> _config:
             kwargs["sym"] = _syms[kwargs["sym"]]
         except KeyError:
             raise YastnError("sym encoded as string only supports: 'dense', 'Z2', 'Z3', 'U1', 'U1xU1', 'U1xU1xZ2'.")
+
+    if "lazy_threshold" not in kwargs:
+        if kwargs["backend"].BACKEND_ID in ["torch_cutensor",]:
+            kwargs["lazy_threshold"] = 0
+        else:
+            kwargs["lazy_threshold"] = 0.5
 
     return _config(**{a: kwargs[a] for a in _config._fields if a in kwargs})
 


### PR DESCRIPTION
- backend-agnostic GPU builder of the cuTensor tensordot metadata: `_meta_tensordot_cutensor_gpu`
  no longer calls torch directly. The array backend is loaded from `backend_id` and injected into
  its helpers, so the GPU meta path can run on any numpy-like backend (torch now; cupy/jax in future).
- new `yastn.backend.import_backend(backend_id)` returning the backend module for a `BACKEND_ID`
  ('np', 'torch', 'torch_cutensor'); `make_config` now uses it to resolve string backends.
- new `make_config` option `meta_tensordot_policy` ('cpu' | 'gpu' | 'auto', default 'auto') selecting
  the algorithm that builds the block-sparsity metadata for `tensordot`; 'auto' uses the GPU builder
  when a GPU device is present, otherwise the CPU builder. Can be overridden with the environment
  variable `YASTN_META_CUTENSOR` = 'GPU' | 'CPU'.
- new `make_config` option `lazy_threshold` (float) controlling lazy initialization of contraction
  outputs — only the blocks actually needed are created instead of all symmetry-allowed blocks —
  based on the fraction of blocks involved; `0` disables lazy evaluation (default for the cuTensor
  backend), values toward `1` enable it more aggressively, and it defaults to `0.5` on other backends.
- backends expose low-level, numpy-aligned array primitives used by the GPU meta:
  `unique`, `searchsorted`, `isin`, `nonzero`, `cumsum`, `concatenate`, `repeat`, `where`,
  `zeros_like`, `full_like`, `arange`; backend `DTYPE` gains `int32` and `int64`.